### PR TITLE
Allow package names to have one character. 

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -4,7 +4,7 @@
      * See README for more details
      */
     exports.PJV = {
-        packageFormat: /^[a-z0-9][a-z0-9\.\-_]+$/,
+        packageFormat: /^[a-z0-9][a-z0-9\.\-_]*$/,
         versionFormat: /^[0-9]+\.[0-9]+[0-9+a-zA-Z\.\-]+$/,
         urlFormat    : /^https*:\/\/[a-z.\-0-9]+/,
         emailFormat  : /\S+@\S+/ // I know this isn't thorough. it's not supposed to be.

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -39,6 +39,13 @@ QUnit.test("Input types", function() {
 
 QUnit.module("NPM");
 
+QUnit.test("Field formats", function() {
+    QUnit.ok(PJV.packageFormat.test("a"), "one alphanumeric character");
+    QUnit.ok(PJV.packageFormat.test("abc123._-"), "url safe characters");
+    QUnit.equal(PJV.packageFormat.test(".abc123"), false, "starts with dot");
+    QUnit.equal(PJV.packageFormat.test("_abc123"), false, "starts with underscore");
+});
+
 QUnit.test("Required fields", function() {
     var json = getPackageJson();
     var result = PJV.validate(JSON.stringify(json), "npm", {warnings: false, recommendations: false});


### PR DESCRIPTION
NPM allows for package names to have one character. 

Updated the package name regex and added some field format tests. Resolves gorillamania/package.json-validator#10
