### PR TITLE
"Person" string/object only requires a name. Allow uppercase characters in package names.

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -288,15 +288,15 @@
         function validatePerson(obj) {
             /* jshint maxcomplexity: 10 */
             if (typeof obj == "string") {
-                if (!/[^<]+<\S+@\S+>/.test(obj)) {
-                    errors.push("String not valid for " + name + ", expected format is Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)");
-                }
+                var authorRegex = /^([^<\(\s]+[^<\(]*)?(\s*<(.*?)>)?(\s*\((.*?)\))?/;
+                var authorFields = authorRegex.exec(obj);
+                var name = authorFields[1],
+                    email = authorFields[3],
+                    url = authorFields[5];
+                validatePerson({"name": name, "email": email, "url": url});
             } else if (typeof obj == "object") {
                 if (!obj.name) {
                     errors.push(name + " field should have name");
-                }
-                if (!obj.email && !obj.url) {
-                    errors.push(name + " field should have email or url");
                 }
                 if (obj.email && !PJV.emailFormat.test(obj.email)) {
                     errors.push("Email not valid for " + name + ": " + obj.email);

--- a/PJV.js
+++ b/PJV.js
@@ -4,7 +4,7 @@
      * See README for more details
      */
     exports.PJV = {
-        packageFormat: /^[a-z0-9][a-z0-9\.\-_]*$/,
+        packageFormat: /^[a-zA-Z0-9][a-zA-Z0-9\.\-_]*$/,
         versionFormat: /^[0-9]+\.[0-9]+[0-9+a-zA-Z\.\-]+$/,
         urlFormat    : /^https*:\/\/[a-z.\-0-9]+/,
         emailFormat  : /\S+@\S+/ // I know this isn't thorough. it's not supposed to be.

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -21,7 +21,7 @@ var npmWarningFields = {
     licenses : [{ "type": "MIT", "url": "http://example.com/license"}],
     contributors: ["Nick Sullivan <nick@sullivanflock.com>"]
 };
- 
+
 
 QUnit.module("Basic");
 
@@ -41,7 +41,7 @@ QUnit.module("NPM");
 
 QUnit.test("Field formats", function() {
     QUnit.ok(PJV.packageFormat.test("a"), "one alphanumeric character");
-    QUnit.ok(PJV.packageFormat.test("abc123._-"), "url safe characters");
+    QUnit.ok(PJV.packageFormat.test("abcABC123._-"), "url safe characters");
     QUnit.equal(PJV.packageFormat.test(".abc123"), false, "starts with dot");
     QUnit.equal(PJV.packageFormat.test("_abc123"), false, "starts with underscore");
     QUnit.equal(PJV.validatePeople("people", "Barney Rubble").length, 0, "author string: name");

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -44,6 +44,9 @@ QUnit.test("Field formats", function() {
     QUnit.ok(PJV.packageFormat.test("abc123._-"), "url safe characters");
     QUnit.equal(PJV.packageFormat.test(".abc123"), false, "starts with dot");
     QUnit.equal(PJV.packageFormat.test("_abc123"), false, "starts with underscore");
+    QUnit.equal(PJV.validatePeople("people", "Barney Rubble").length, 0, "author string: name");
+    QUnit.equal(PJV.validatePeople("people", "Barney Rubble <b@rubble.com> (http://barneyrubble.tumblr.com/)").length, 0, "author string: name, email, url");
+    QUnit.equal(PJV.validatePeople("people", "<b@rubble.com> (http://barneyrubble.tumblr.com/)").length > 0, 1, "author string: name required");
 });
 
 QUnit.test("Required fields", function() {


### PR DESCRIPTION
"Person" string/object only requires a name. 
Removed email and url requirement for Person string and object. Updated the regex and logic for validating the "Person" string. Unit tests added.
Resolves gorillamania/package.json-validator#12

Allow uppercase characters in package names. 
Resolves gorillamania/package.json-validator#14
