### PR TITLE
bin field should allow strings and objects.

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -170,7 +170,7 @@
             if (field.types || field.type) {
                 var typeErrors = PJV.validateType(name, field, parsed[name]);
                 if(typeErrors.length > 0) {
-                    errors.concat(typeErrors);
+                    errors = errors.concat(typeErrors);
                     continue;
                 }
             }
@@ -203,10 +203,10 @@
 
     PJV.validateType = function(name, field, value) {
         var errors = [];
-        var types = field.types || [field.type];
-        if ((types.indexOf("array") != -1 && !value instanceof Array)
-            || (types.indexOf("array") == -1 && types.indexOf(typeof value) == -1)) {
-            errors.push("Type for field " + name + ", was expected to be " + types.join(" or ") + ", not " + typeof value);
+        var validFieldTypes = field.types || [field.type];
+        var valueType = value instanceof Array ? "array" : typeof value;
+        if(validFieldTypes.indexOf(valueType) == -1) {
+            errors.push("Type for field " + name + ", was expected to be " + validFieldTypes.join(" or ") + ", not " + typeof value);
         }
         return errors;
     };

--- a/PJV.js
+++ b/PJV.js
@@ -28,7 +28,7 @@
                 "author":       {required: true, validate: PJV.validatePeople},
                 "contributors": {warning: true, validate: PJV.validatePeople},
                 "files":        {"type": "array"},
-                "main":         {"type": "array"},
+                "main":         {"type": "string"},
                 "bin":          {"types": ["string", "object"]},
                 "man":          {"type": "object"},
                 "directories":  {"type": "object"},
@@ -79,7 +79,7 @@
             return {
                 "name":         {"type": "string", required: true, format: PJV.packageFormat},
                 "version":      {"type": "string", required: true, format: PJV.versionFormat},
-                "main":         {"type": "array", required: true},
+                "main":         {"type": "string", required: true},
                 "directories":  {"type": "object", required: true},
 
                 "maintainers":  {"type": "array", warning: true, validate: PJV.validatePeople},

--- a/PJV.js
+++ b/PJV.js
@@ -29,7 +29,7 @@
                 "contributors": {warning: true, validate: PJV.validatePeople},
                 "files":        {"type": "array"},
                 "main":         {"type": "array"},
-                "bin":          {"type": "object"},
+                "bin":          {"types": ["string", "object"]},
                 "man":          {"type": "object"},
                 "directories":  {"type": "object"},
                 "repository":   {"type": "object", warning: true, validate: PJV.validateUrlTypes, or: "repositories"},
@@ -167,10 +167,10 @@
             }
 
             // Type checking
-            if (field.type) {
-                if ((field.type == "array" && !parsed[name] instanceof Array)
-                        || (field.type != "array" && typeof parsed[name] != field.type)) {
-                    errors.push("Type for field " + name + ", was expected to be " + field.type + ", not " + typeof parsed[name]);
+            if (field.types || field.type) {
+                var typeErrors = PJV.validateType(name, field, parsed[name]);
+                if(typeErrors.length > 0) {
+                    errors.concat(typeErrors);
                     continue;
                 }
             }
@@ -199,6 +199,16 @@
         }
 
         return out;
+    };
+
+    PJV.validateType = function(name, field, value) {
+        var errors = [];
+        var types = field.types || [field.type];
+        if ((types.indexOf("array") != -1 && !value instanceof Array)
+            || (types.indexOf("array") == -1 && types.indexOf(typeof value) == -1)) {
+            errors.push("Type for field " + name + ", was expected to be " + types.join(" or ") + ", not " + typeof value);
+        }
+        return errors;
     };
 
     // Validates dependencies, making sure the object is a set of key value pairs

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -47,6 +47,8 @@ QUnit.test("Field formats", function() {
     QUnit.equal(PJV.validatePeople("people", "Barney Rubble").length, 0, "author string: name");
     QUnit.equal(PJV.validatePeople("people", "Barney Rubble <b@rubble.com> (http://barneyrubble.tumblr.com/)").length, 0, "author string: name, email, url");
     QUnit.equal(PJV.validatePeople("people", "<b@rubble.com> (http://barneyrubble.tumblr.com/)").length > 0, 1, "author string: name required");
+    QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: "./path/to/program"})), "npm").valid, true, "bin: can be string");
+    QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: {"my-project": "./path/to/program"}})), "npm").valid, true, "bin: can be object");
 });
 
 QUnit.test("Required fields", function() {

--- a/test/qunit-pjv.js
+++ b/test/qunit-pjv.js
@@ -49,6 +49,7 @@ QUnit.test("Field formats", function() {
     QUnit.equal(PJV.validatePeople("people", "<b@rubble.com> (http://barneyrubble.tumblr.com/)").length > 0, 1, "author string: name required");
     QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: "./path/to/program"})), "npm").valid, true, "bin: can be string");
     QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: {"my-project": "./path/to/program"}})), "npm").valid, true, "bin: can be object");
+    QUnit.equal(PJV.validate(JSON.stringify(getPackageJson({bin: ["./path/to/program"]})), "npm").valid, false, "bin: can't be an array");
 });
 
 QUnit.test("Required fields", function() {


### PR DESCRIPTION
bin field should allow strings and objects. Added support for checking multiple types for a field value. Unit tests added.
Resolves gorillamania/package.json-validator#17

While resolving this issue, I noticed that arrays weren't properly being validated. Fixed logic for this and added some unit tests.

In a related issue, "main" field should be a string and not an array according to spec for npm and commonjs.
