### PR TITLE
Repository field supports both string and object.

### DIFF
--- a/PJV.js
+++ b/PJV.js
@@ -32,7 +32,7 @@
                 "bin":          {"types": ["string", "object"]},
                 "man":          {"type": "object"},
                 "directories":  {"type": "object"},
-                "repository":   {"type": "object", warning: true, validate: PJV.validateUrlTypes, or: "repositories"},
+                "repository":   {"type": ["string","object"], warning: true, validate: PJV.validateUrlTypes, or: "repositories"},
                 "scripts":      {"type": "object"},
                 "config":       {"type": "object"},
                 "dependencies": {"type": "object", recommended: true, validate: PJV.validateDependencies},


### PR DESCRIPTION
It might be just `"repository": "hemanth/generator-atom"`
