### PR TITLE
build: bundle build files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - src/bin/pjv.ts # bin script entry point

--- a/src/PJV.ts
+++ b/src/PJV.ts
@@ -3,15 +3,15 @@ import {
 	packageFormat,
 	urlFormat,
 	versionFormat,
-} from "./formats.js";
-import { validate } from "./validate.js";
+} from "./formats";
+import { validate } from "./validate";
 import {
 	validateDependencies,
 	validatePeople,
 	validateType,
 	validateUrlOrMailto,
 	validateUrlTypes,
-} from "./validators/index.js";
+} from "./validators";
 
 /** @deprecated please use the individual {@link validate} function */
 export const PJV = {

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -7,11 +7,10 @@
  */
 import fs from "node:fs";
 import process from "node:process";
+import { validate } from "package-json-validator";
 import yargs from "yargs";
 
 import type { SpecName } from "../types";
-
-import { validate } from "../validate.js";
 
 interface Options {
 	filename: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { PJV } from "./PJV.js";
+export { PJV } from "./PJV";
 export type { SpecName, SpecType } from "./types";
-export { validate } from "./validate.js";
-export { validateAuthor, validateBin } from "./validators/index.js";
+export { validate } from "./validate";
+export { validateAuthor, validateBin } from "./validators";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,6 @@
 import type { SpecMap, SpecName } from "./types";
 
-import { packageFormat, urlFormat, versionFormat } from "./formats.js";
+import { packageFormat, urlFormat, versionFormat } from "./formats";
 import {
 	validateAuthor,
 	validateBin,
@@ -9,7 +9,7 @@ import {
 	validateType,
 	validateUrlOrMailto,
 	validateUrlTypes,
-} from "./validators/index.js";
+} from "./validators";
 
 const getSpecMap = (
 	specName: SpecName,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,7 +1,7 @@
-export { validateAuthor } from "./validateAuthor.js";
-export { validateBin } from "./validateBin.js";
-export { validateDependencies } from "./validateDependencies.js";
-export { validatePeople } from "./validatePeople.js";
-export { validateType } from "./validateType.js";
-export { validateUrlOrMailto } from "./validateUrlOrMailto.js";
-export { validateUrlTypes } from "./validateUrlTypes.js";
+export { validateAuthor } from "./validateAuthor";
+export { validateBin } from "./validateBin";
+export { validateDependencies } from "./validateDependencies";
+export { validatePeople } from "./validatePeople";
+export { validateType } from "./validateType";
+export { validateUrlOrMailto } from "./validateUrlOrMailto";
+export { validateUrlTypes } from "./validateUrlTypes";

--- a/src/validators/validateAuthor.ts
+++ b/src/validators/validateAuthor.ts
@@ -1,4 +1,4 @@
-import { isPerson, validatePeople } from "./validatePeople.js";
+import { isPerson, validatePeople } from "./validatePeople";
 
 /**
  * Validate the `author` field in a package.json, which can either be a person

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -1,4 +1,4 @@
-import { packageFormat, urlFormat } from "../formats.js";
+import { packageFormat, urlFormat } from "../formats";
 
 const isValidVersionRange = (v: string): boolean => {
 	// https://github.com/isaacs/npm/blob/master/doc/cli/json.md#dependencies

--- a/src/validators/validatePeople.ts
+++ b/src/validators/validatePeople.ts
@@ -1,6 +1,6 @@
 import type { People, Person } from "../types";
 
-import { emailFormat, urlFormat } from "../formats.js";
+import { emailFormat, urlFormat } from "../formats";
 
 export const isPersonArray = (obj: unknown): obj is Person[] => {
 	return Array.isArray(obj) && obj.every((item) => isPerson(item));

--- a/src/validators/validateUrlOrMailto.ts
+++ b/src/validators/validateUrlOrMailto.ts
@@ -1,6 +1,6 @@
 import type { UrlOrMailTo } from "../types";
 
-import { emailFormat, urlFormat } from "../formats.js";
+import { emailFormat, urlFormat } from "../formats";
 
 /**
  * Allows for a url as a string, or an object that looks like:

--- a/src/validators/validateUrlTypes.ts
+++ b/src/validators/validateUrlTypes.ts
@@ -1,6 +1,6 @@
 import type { UrlType } from "../types";
 
-import { urlFormat } from "../formats.js";
+import { urlFormat } from "../formats";
 
 /**
  * Format for license(s) and repository(s):

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
 		"rewriteRelativeImportExtensions": true,
 		"skipLibCheck": true,
 		"strict": true,
-		"target": "ES2022"
+		"target": "ES2022",
+		"paths": {
+			"package-json-validator": ["./src/index.ts"]
+		}
 	},
 	"include": ["src"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	bundle: false,
 	clean: true,
 	dts: true,
-	entry: ["src/**/*.ts", "!src/**/*.test.*"],
+	entry: ["src/index.ts", "src/bin/pjv.ts"],
+	external: ["package-json-validator"],
 	format: ["cjs", "esm"],
 	outDir: "lib",
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-	clean: true,
-	dts: true,
-	entry: ["src/index.ts", "src/bin/pjv.ts"],
-	external: ["package-json-validator"],
-	format: ["cjs", "esm"],
-	outDir: "lib",
-});
+export default defineConfig([
+	{
+		clean: true,
+		dts: true,
+		entry: ["src/index.ts"],
+		format: ["cjs", "esm"],
+		outDir: "lib",
+	},
+	{
+		dts: false,
+		entry: ["src/bin/pjv.ts"],
+		external: ["package-json-validator"],
+		format: ["esm"],
+		outDir: "lib/bin",
+	},
+]);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #259 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change is focused on optimizing our package, and to address a known bug with how we were handling support for both cjs and esm.

With this change, we're now bundling the two main entry points:
- the root of our js/ts api
- the cli bin

As part of multi-entry point best practices, I changed the import of `validate` in the second entry-point to reference the package (the first entry point), rather than having a relative path.  That way we aren't doubling up on the bundles.  I also set up the `tsup` config to not generate a `.d.ts` for the `bin` script, since that's only being run from the cli, and not part of the TS api.

Package size (packed) before: 18kb
Package size (packed) after: 14kb

Package size (unpacked) before: 63.3kb
Package size (unpacked) after: 36.5kb

Much cleaner package structure ✨ 

![package structure](https://github.com/user-attachments/assets/1ab5f041-e58b-4009-b402-b250c9c2357a)
