### PR TITLE
feat(validateDependencies): Improve dependency name validation

### DIFF
--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -5,6 +5,7 @@ import { validateDependencies } from "./validateDependencies.js";
 describe("validateDependencies", () => {
 	it("should validate dependencies with no errors", () => {
 		const dependencies = {
+			"absolute-path-without-protocol": "/absolute/path",
 			"caret-first": "^1.0.0",
 			"caret-top": "^1",
 			"catalog-named-package": "catalog:react19",
@@ -19,6 +20,9 @@ describe("validateDependencies", () => {
 			lteq: "<=1.2.3",
 			range: "1.2.3 - 2.3.4",
 			relative: "file:../relative/path",
+			"relative-parent-without-protocol": "../relative/path",
+			"relative-subdir-without-protocol": "./relative/path",
+			"relative-tilde-without-protocol": "~/path",
 			star: "*",
 			"svgo-v1": "npm:svgo@1.3.2",
 			"svgo-v2": "npm:svgo@2.0.3",
@@ -35,10 +39,71 @@ describe("validateDependencies", () => {
 			"x-version": "1.2.x",
 			// reference: https://github.com/JoshuaKGoldberg/package-json-validator/issues/49
 			"@reactivex/rxjs": "^5.0.0-alpha.7",
+			"git-https-reference": "git+https://isaacs@github.com/npm/cli.git",
+			"git-reference": "git://github.com/npm/cli.git#v1.0.27",
+			"git-ssh-reference": "git+ssh://git@github.com:npm/cli#semver:^5.0",
+			"github-reference": "github:some/package",
+			"github-reference-no-protocol": "some/package",
+			"github-reference-with-hash": "some/package#feature/branch",
 		};
 
 		const result = validateDependencies("dependencies", dependencies);
 		expect(result).toEqual([]);
+	});
+
+	it("should only validate the package name for published-looking versions", () => {
+		const publishedDependencies = {
+			"_caret-first": "^1.0.0",
+			_empty: "",
+			_gt: ">1.2.3",
+			_gteq: ">=1.2.3",
+			"_jsr-package": "jsr:^1.0.0",
+			"_jsr-package-exact": "jsr:1.0.0",
+			"_jsr-scoped-package": "jsr:@valibot/valibot@^1.0.0",
+			_lt: "<1.2.3",
+			_lteq: "<=1.2.3",
+			_range: "1.2.3 - 2.3.4",
+			_star: "*",
+			"_tilde-first": "~1.2",
+			"_tilde-top": "~1",
+			"_verion-build": "1.2.3+build2012",
+			"_x-version": "1.2.x",
+		};
+		const unpublishedDependencies = {
+			"_absolute-path-without-protocol": "/absolute/path",
+			"_catalog-named-package": "catalog:react19",
+			"_catalog-package": "catalog:",
+			"_git-https-reference": "git+https://isaacs@github.com/npm/cli.git",
+			"_git-reference": "git://github.com/npm/cli.git#v1.0.27",
+			"_git-ssh-reference": "git+ssh://git@github.com:npm/cli#semver:^5.0",
+			"_github-reference": "github:some/package",
+			"_github-reference-no-protocol": "some/package",
+			"_github-reference-with-hash": "some/package#feature/branch",
+			_relative: "file:../relative/path",
+			"_relative-parent-without-protocol": "../relative/path",
+			"_relative-subdir-without-protocol": "./relative/path",
+			"_relative-tilde-without-protocol": "~/path",
+			"_svgo-v1": "npm:svgo@1.3.2",
+			"_svgo-v2": "npm:svgo@2.0.3",
+			_url: "https://github.com/JoshuaKGoldberg/package-json-validator",
+			"_workspace-gt-version": "workspace:>1.2.3",
+			"_workspace-package-any": "workspace:*",
+			"_workspace-package-caret": "workspace:^",
+			"_workspace-package-no-range": "workspace:",
+			"_workspace-package-tilde-version": "workspace:~1.2.3",
+			"_workspace-pre-release": "workspace:1.2.3-rc.1",
+		};
+
+		const result = validateDependencies("dependencies", {
+			...publishedDependencies,
+			...unpublishedDependencies,
+		});
+		assert.deepStrictEqual(
+			result,
+			Object.keys(publishedDependencies).map(
+				(k) => `Invalid dependency package name: ${k}`,
+			),
+		);
 	});
 
 	it("should report an error when dependencies have an invalid range", () => {
@@ -48,6 +113,10 @@ describe("validateDependencies", () => {
 			"bad-npm": "npm;svgo@^1.2.3",
 			"bad-workspace": "workspace:abc123",
 			"bad-workspace-range": "workspace:^>1.2.3",
+			"invalid-git-protocol": "git+foo://github.com/npm/cli.git",
+			"invalid-github-reference-bad-reponame": "some/package?",
+			"invalid-github-reference-bad-username": "some--user/package",
+			"invalid-github-reference-too-many-slashes": "some/package/subpath",
 			"package-name": "abc123",
 		};
 
@@ -59,6 +128,10 @@ describe("validateDependencies", () => {
 			"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 			"Invalid version range for dependency bad-workspace: workspace:abc123",
 			"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+			"Invalid version range for dependency invalid-git-protocol: git+foo://github.com/npm/cli.git",
+			"Invalid version range for dependency invalid-github-reference-bad-reponame: some/package?",
+			"Invalid version range for dependency invalid-github-reference-bad-username: some--user/package",
+			"Invalid version range for dependency invalid-github-reference-too-many-slashes: some/package/subpath",
 			"Invalid version range for dependency package-name: abc123",
 		]);
 	});

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -54,6 +54,8 @@ describe("validateDependencies", () => {
 	it("should only validate the package name for published-looking versions", () => {
 		const publishedDependencies = {
 			"_caret-first": "^1.0.0",
+			"_catalog-named-package": "catalog:react19",
+			"_catalog-package": "catalog:",
 			_empty: "",
 			_gt: ">1.2.3",
 			_gteq: ">=1.2.3",
@@ -71,8 +73,6 @@ describe("validateDependencies", () => {
 		};
 		const unpublishedDependencies = {
 			"_absolute-path-without-protocol": "/absolute/path",
-			"_catalog-named-package": "catalog:react19",
-			"_catalog-package": "catalog:",
 			"_git-https-reference": "git+https://isaacs@github.com/npm/cli.git",
 			"_git-reference": "git://github.com/npm/cli.git#v1.0.27",
 			"_git-ssh-reference": "git+ssh://git@github.com:npm/cli#semver:^5.0",

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -10,8 +10,6 @@ const isUnpublishedVersion = (v: string): boolean => {
 		/^(?:github:)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*\/[\w.-]+(?:#|$)/.test(v) ||
 		// https://pnpm.io/next/workspaces#workspace-protocol-workspace
 		/^workspace:((\^|~)?[0-9.x]*|(<=?|>=?)?[0-9.x][\-.+\w]+|\*)?$/.test(v) ||
-		// https://pnpm.io/next/catalogs
-		v.startsWith("catalog:") ||
 		// https://docs.npmjs.com/cli/v11/using-npm/package-spec#aliases
 		v.startsWith("npm:") ||
 		// https://docs.npmjs.com/cli/v10/configuring-npm/package-json#local-paths
@@ -33,6 +31,12 @@ const isValidVersionRange = (v: string): boolean => {
 		v === "latest" ||
 		// https://jsr.io/docs/using-packages
 		v.startsWith("jsr:") ||
+		// https://pnpm.io/next/catalogs
+		// These could be published or unpublished. Ideally linting would validate the
+		// catalog itself, and then we could ignore the package names here since they'd be
+		// correctly validated there. But the catalog is elsewhere, and the better
+		// assumption is that it mostly has published packages.
+		v.startsWith("catalog:") ||
 		isUnpublishedVersion(v) ||
 		false
 	);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/1165
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
* Tighten recognition of `git` and `github` protocols. Instead of anything starting with `git`, look for actual `git:`, `git+ssh:`, `github:`, and so on.
* Recognize [GitHub shorthand](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#github-urls).
* Recognize paths without `file:` prefix.
* Only enforce npmjs.com package name restrictions for versions that look like they'd be resolved from a published package, not e.g. workspaces, relative paths, git refs, github refs, or aliases, by splitting `isUnpublishedVersion` from `isValidVersionRange` and using the former in the check for valid package names.
  This is per request at https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/1165#issuecomment-3054338310

💖