### PR TITLE
feat(validateDependencies): add function for validating `dependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,33 @@ const packageData = {
 const errors = validateCpu(packageData.cpu);
 ```
 
+### validateDependencies(value)
+
+This function validates the value of the `dependency` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- It should be of type an `object`.
+- The object should be a record of key value pairs
+- For each property, the key should be a valid package name, and the value should be a valid version
+
+It returns a list of error messages, if any violations are found.
+
+#### Examples
+
+```ts
+import { validateDependencies } from "package-json-validator";
+
+const packageData = {
+	dependencies: {
+		"@catalog/package": "catalog:",
+		"@my/package": "^1.2.3",
+		"@workspace/package": "workspace:^",
+	},
+};
+
+const errors = validateBin(packageData.dependencies);
+```
+
 ### validateLicense(value)
 
 This function validates the value of the `license` property of a `package.json`.

--- a/src/PJV.test.ts
+++ b/src/PJV.test.ts
@@ -127,27 +127,27 @@ describe("PJV", () => {
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-catalog: catalob:",
+							"invalid version range for dependency bad-catalog: catalob:",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace: workspace:abc123",
+							"invalid version range for dependency bad-workspace: workspace:abc123",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+							"invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -165,7 +165,7 @@ describe("PJV", () => {
 					{
 						field: "peerDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -375,27 +375,27 @@ describe("PJV", () => {
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-catalog: catalob:",
+							"invalid version range for dependency bad-catalog: catalob:",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace: workspace:abc123",
+							"invalid version range for dependency bad-workspace: workspace:abc123",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+							"invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -413,7 +413,7 @@ describe("PJV", () => {
 					{
 						field: "peerDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
 	validateBundleDependencies,
 	validateConfig,
 	validateCpu,
+	validateDependencies,
 	validateLicense,
 	validateScripts,
 	validateType,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -157,27 +157,27 @@ describe("validate", () => {
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-catalog: catalob:",
+							"invalid version range for dependency bad-catalog: catalob:",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace: workspace:abc123",
+							"invalid version range for dependency bad-workspace: workspace:abc123",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+							"invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -195,7 +195,7 @@ describe("validate", () => {
 					{
 						field: "peerDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -402,27 +402,27 @@ describe("validate", () => {
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-catalog: catalob:",
+							"invalid version range for dependency bad-catalog: catalob:",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace: workspace:abc123",
+							"invalid version range for dependency bad-workspace: workspace:abc123",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+							"invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
 					},
 					{
 						field: "devDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});
@@ -440,7 +440,7 @@ describe("validate", () => {
 					{
 						field: "peerDependencies",
 						message:
-							"Invalid version range for dependency package-name: abc123",
+							"invalid version range for dependency package-name: abc123",
 					},
 				]);
 			});

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -42,11 +42,10 @@ const getSpecMap = (
 			cpu: { validate: (_, value) => validateCpu(value) },
 			dependencies: {
 				recommended: true,
-				type: "object",
-				validate: validateDependencies,
+				validate: (_, value) => validateDependencies(value),
 			},
 			description: { type: "string", warning: true },
-			devDependencies: { type: "object", validate: validateDependencies },
+			devDependencies: { validate: (_, value) => validateDependencies(value) },
 			directories: { type: "object" },
 			engines: { recommended: true, type: "object" },
 			engineStrict: { type: "boolean" },
@@ -68,13 +67,11 @@ const getSpecMap = (
 				type: "string",
 			},
 			optionalDependencies: {
-				type: "object",
-				validate: validateDependencies,
+				validate: (_, value) => validateDependencies(value),
 			},
 			os: { type: "array" },
 			peerDependencies: {
-				type: "object",
-				validate: validateDependencies,
+				validate: (_, value) => validateDependencies(value),
 			},
 			preferGlobal: { type: "boolean" },
 			private: { type: "boolean" },
@@ -110,8 +107,7 @@ const getSpecMap = (
 			cpu: { type: "array" },
 			dependencies: {
 				required: true,
-				type: "object",
-				validate: validateDependencies,
+				validate: (_, value) => validateDependencies(value),
 			},
 			description: { required: true, type: "string" },
 			directories: { type: "object" },
@@ -153,7 +149,7 @@ const getSpecMap = (
 			contributors: { type: "array", validate: validatePeople },
 
 			cpu: { type: "array" },
-			dependencies: { type: "object", validate: validateDependencies },
+			dependencies: { validate: (_, value) => validateDependencies(value) },
 			description: { type: "string", warning: true },
 			directories: { required: true, type: "object" },
 			engine: { type: "array" },

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -3,6 +3,11 @@ import { assert, describe, expect, it } from "vitest";
 import { validateDependencies } from "./validateDependencies.js";
 
 describe("validateDependencies", () => {
+	it("should return no errors if the value is an empty object", () => {
+		const result = validateDependencies({});
+		expect(result).toEqual([]);
+	});
+
 	it("should validate dependencies with no errors", () => {
 		const dependencies = {
 			"absolute-path-without-protocol": "/absolute/path",
@@ -47,7 +52,7 @@ describe("validateDependencies", () => {
 			"github-reference-with-hash": "some/package#feature/branch",
 		};
 
-		const result = validateDependencies("dependencies", dependencies);
+		const result = validateDependencies(dependencies);
 		expect(result).toEqual([]);
 	});
 
@@ -94,14 +99,14 @@ describe("validateDependencies", () => {
 			"_workspace-pre-release": "workspace:1.2.3-rc.1",
 		};
 
-		const result = validateDependencies("dependencies", {
+		const result = validateDependencies({
 			...publishedDependencies,
 			...unpublishedDependencies,
 		});
 		assert.deepStrictEqual(
 			result,
 			Object.keys(publishedDependencies).map(
-				(k) => `Invalid dependency package name: ${k}`,
+				(k) => `invalid dependency package name: ${k}`,
 			),
 		);
 	});
@@ -120,19 +125,41 @@ describe("validateDependencies", () => {
 			"package-name": "abc123",
 		};
 
-		const result = validateDependencies("dependencies", dependencies);
+		const result = validateDependencies(dependencies);
 
 		assert.deepStrictEqual(result, [
-			"Invalid version range for dependency bad-catalog: catalob:",
-			"Invalid version range for dependency bad-jsr: jsr;@scope/package@^1.0.0",
-			"Invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-			"Invalid version range for dependency bad-workspace: workspace:abc123",
-			"Invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
-			"Invalid version range for dependency invalid-git-protocol: git+foo://github.com/npm/cli.git",
-			"Invalid version range for dependency invalid-github-reference-bad-reponame: some/package?",
-			"Invalid version range for dependency invalid-github-reference-bad-username: some--user/package",
-			"Invalid version range for dependency invalid-github-reference-too-many-slashes: some/package/subpath",
-			"Invalid version range for dependency package-name: abc123",
+			"invalid version range for dependency bad-catalog: catalob:",
+			"invalid version range for dependency bad-jsr: jsr;@scope/package@^1.0.0",
+			"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+			"invalid version range for dependency bad-workspace: workspace:abc123",
+			"invalid version range for dependency bad-workspace-range: workspace:^>1.2.3",
+			"invalid version range for dependency invalid-git-protocol: git+foo://github.com/npm/cli.git",
+			"invalid version range for dependency invalid-github-reference-bad-reponame: some/package?",
+			"invalid version range for dependency invalid-github-reference-bad-username: some--user/package",
+			"invalid version range for dependency invalid-github-reference-too-many-slashes: some/package/subpath",
+			"invalid version range for dependency package-name: abc123",
+		]);
+	});
+
+	it("should return an error if the value is a string", () => {
+		const result = validateDependencies("123");
+		expect(result).toEqual(["the type should be `object`, not `string`"]);
+	});
+
+	it("should return an error if the value is a number", () => {
+		const result = validateDependencies(123);
+		expect(result).toEqual(["the type should be `object`, not `number`"]);
+	});
+
+	it("should return an error if the value is an object", () => {
+		const result = validateDependencies([]);
+		expect(result).toEqual(["the type should be `object`, not `array`"]);
+	});
+
+	it("should return an error if the value is null", () => {
+		const result = validateDependencies(null);
+		expect(result).toEqual([
+			"the field is `null`, but should be a record of dependencies",
 		]);
 	});
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #312, #342
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateDependencies` function that validates the value of the "dependencies" field of a package.json. It returns a list of error messages if a violation is found. Validation of `dependencies`, `optionalDependencies`, `devDependencies`, and `peerDependencies` in the monolithic validate function have been switched over to use this function as well. That means the criteria for these properties, when running `validate`, is stricter.

In addition to the previous validations, it uses `semver` validate version ranges, and does more to validate the shape of the object.
