### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -13,8 +13,6 @@ body:
       options:
         - label: I have tried restarting my IDE and the issue persists.
           required: true
-        - label: I have pulled the latest `main` branch of the repository.
-          required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
@@ -30,6 +28,12 @@ body:
     type: textarea
     validations:
       required: true
+  - attributes:
+      description: Version of this package you tried
+      label: Version
+      placeholder: 1.2.3
+      required: true
+    type: input
   - attributes:
       description: Any additional info you'd like to provide.
       label: Additional Info

--- a/.github/ISSUE_TEMPLATE/02-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/02-documentation.yml
@@ -11,7 +11,7 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Documentation Report Checklist
       options:
-        - label: I have pulled the latest `main` branch of the repository.
+        - label: I have checked the latest `main` branch of the repository.
           required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aissue) and found none that matched my issue.
           required: true

--- a/.github/ISSUE_TEMPLATE/03-feature.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature.yml
@@ -11,13 +11,11 @@ body:
       description: If any of these required steps are not taken, we may not be able to review your issue. Help us to help you!
       label: Feature Request Checklist
       options:
-        - label: I have pulled the latest `main` branch of the repository.
-          required: true
         - label: I have [searched for related issues](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aissue) and found none that matched my issue.
           required: true
     type: checkboxes
   - attributes:
-      description: What did you expect to be able to do?
+      description: What would you like to be able to do?
       label: Overview
     type: textarea
     validations:

--- a/.github/ISSUE_TEMPLATE/05-tooling.yml
+++ b/.github/ISSUE_TEMPLATE/05-tooling.yml
@@ -19,7 +19,7 @@ body:
           required: true
     type: checkboxes
   - attributes:
-      description: What did you expect to be able to do?
+      description: What tooling changes would you like to make?
       label: Overview
     type: textarea
     validations:


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The main motivation for this change was to add a version input field for the bug template.

But I went ahead and also made some minor tweaks to the other templates to make them more focused.
