### PR TITLE
feat(validateBin): adopt new Result return type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const packageData = {
 	},
 };
 
-const errors = validateAuthor(packageData.author);
+const result = validateAuthor(packageData.author);
 ```
 
 ```ts
@@ -201,7 +201,7 @@ const packageData = {
 	author: "Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)",
 };
 
-const errors = validateAuthor(packageData.author);
+const result = validateAuthor(packageData.author);
 ```
 
 ### validateBin(value)
@@ -213,7 +213,7 @@ It takes the value, and validates it against the following criteria.
 - If it's a `string`, it should be a relative path to an executable file.
 - If it's an `object`, it should be a key to string value object, and the values should all be relative paths.
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -224,7 +224,7 @@ const packageData = {
 	bin: "./my-cli.js",
 };
 
-const errors = validateBin(packageData.bin);
+const result = validateBin(packageData.bin);
 ```
 
 ```ts
@@ -237,7 +237,7 @@ const packageData = {
 	},
 };
 
-const errors = validateBin(packageData.bin);
+const result = validateBin(packageData.bin);
 ```
 
 ### validateBundleDependencies(value)

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -48,6 +48,21 @@ export const createValidationResult = (
 };
 
 /**
+ * Given an index and all the parameters of `createValidationResult`, this function creates a new ChildResult object.
+ * @param index The index for this ChildResult.
+ * @param args The params for the call to `createValidationResult`
+ * @see {@link createValidationResult}
+ * @returns The new ChildResult object
+ */
+export const createChildResult = (
+	index: number,
+	...args: Parameters<typeof createValidationResult>
+): ChildResult => {
+	const result = createValidationResult(...args);
+	return { ...result, index };
+};
+
+/**
  * Adds a new child result to a parent result, adding the child's error messages to the parents, and
  * appending the child result to the parent's childResults array.
  * @param parent the parent Result object

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -35,7 +35,7 @@ const getSpecMap = (
 				validate: (_, value) => validateAuthor(value).errorMessages,
 				warning: true,
 			},
-			bin: { validate: (_, value) => validateBin(value) },
+			bin: { validate: (_, value) => validateBin(value).errorMessages },
 			bugs: { validate: validateUrlOrMailto, warning: true },
 			bundledDependencies: {
 				validate: (_, value) => validateBundleDependencies(value),

--- a/src/validators/validateBin.test.ts
+++ b/src/validators/validateBin.test.ts
@@ -1,92 +1,138 @@
 import { describe, expect, it } from "vitest";
 
+import { createChildResult, createValidationResult } from "../Result.ts";
 import { validateBin } from "./validateBin.ts";
 
 describe("validateBin", () => {
-	it("should return no errors if the bin field is an empty object", () => {
+	it("should return a Result with no issues if the bin field is an empty object", () => {
 		const result = validateBin({});
-		expect(result).toEqual([]);
+		expect(result).toEqual(createValidationResult());
 	});
 
 	it.each(["./cli.js", "cli.js", "./bin/cli.js", "bin/cli.js"])(
-		"should return no errors if the bin field is a valid string: %s",
+		"should return a Result with no issues if the bin field is a valid string: %s",
 		(binPath) => {
 			const result = validateBin(binPath);
-			expect(result).toEqual([]);
+			expect(result).toEqual(createValidationResult());
 		},
 	);
 
-	it("should return an error if the bin field is an empty string", () => {
+	it("should return a Result with one issue when the bin field is an empty string", () => {
 		const result = validateBin("");
-		expect(result).toEqual([
-			"bin field is empty, but should be a relative path",
-		]);
+		expect(result).toEqual(
+			createValidationResult(["field is empty, but should be a relative path"]),
+		);
 	});
 
-	it("should return no errors if the bin field is a valid object with all keys having valid strings", () => {
+	it("should return a Result with ChildResults that have no issues if the bin field is a valid object with all keys having valid strings", () => {
 		const result = validateBin({
 			"my-cli": "cli.js",
 			"my-dev-tool": "./dev-tool.js",
 			"my-other-cli": "bin/cli.js",
 			"my-other-tool": "./tools/other-tool.js",
 		});
-		expect(result).toEqual([]);
+		expect(result).toEqual(
+			createValidationResult(
+				[],
+				[
+					createChildResult(0, []),
+					createChildResult(1, []),
+					createChildResult(2, []),
+					createChildResult(3, []),
+				],
+			),
+		);
 	});
 
-	it("should return errors if the bin field is an object with some keys having invalid paths", () => {
+	it("should return a Result with ChildResults that have issues if the bin field is an object with some keys having invalid paths", () => {
 		const result = validateBin({
 			"my-cli": "./cli.js",
 			"my-dev-tool": "",
 			"my-other-tool": "  ",
 		});
-		expect(result).toEqual([
-			'bin field "my-dev-tool" is empty, but should be a relative path',
-			'bin field "my-other-tool" is empty, but should be a relative path',
-		]);
+		expect(result).toEqual(
+			createValidationResult(
+				[],
+				[
+					createChildResult(0, []),
+					createChildResult(1, [
+						'bin field "my-dev-tool" is empty, but should be a relative path',
+					]),
+					createChildResult(2, [
+						'bin field "my-other-tool" is empty, but should be a relative path',
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the bin field is an object with an empty string key", () => {
+	it("should return a Result with ChildResults that have issues if the bin field is an object with an empty string key", () => {
 		const result = validateBin({
 			"": "./cli.js",
 			"  ": "./dev-tool.js",
 			"    ": "",
 		});
-		expect(result).toEqual([
-			"bin field 0 has an empty key, but should be a valid command name",
-			"bin field 1 has an empty key, but should be a valid command name",
-			"bin field 2 is empty, but should be a relative path",
-			"bin field 2 has an empty key, but should be a valid command name",
-		]);
+		expect(result).toEqual(
+			createValidationResult(
+				[],
+				[
+					createChildResult(0, [
+						"bin field 0 has an empty key, but should be a valid command name",
+					]),
+					createChildResult(1, [
+						"bin field 1 has an empty key, but should be a valid command name",
+					]),
+					createChildResult(2, [
+						"bin field 2 is empty, but should be a relative path",
+						"bin field 2 has an empty key, but should be a valid command name",
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return errors if the bin field is an object with some keys having non-string values", () => {
+	it("should return a Result with ChildResults that have issues if the bin field is an object with some keys having non-string values", () => {
 		const result = validateBin({
 			"my-cli": "./cli.js",
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			"my-dev-tool": 123 as any,
 		});
-		expect(result).toEqual(['bin field "my-dev-tool" should be a string']);
+		expect(result).toEqual(
+			createValidationResult(
+				[],
+				[
+					createChildResult(0),
+					createChildResult(1, ['bin field "my-dev-tool" should be a string']),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the bin field is neither a string nor an object", () => {
+	it("should return a Result with an issue if the bin field is neither a string nor an object", () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const result = validateBin(123 as any);
-		expect(result).toEqual([
-			'Type for field "bin" should be `string` or `object`, not `number`',
-		]);
+		expect(result).toEqual(
+			createValidationResult([
+				"type should be `string` or `object`, not `number`",
+			]),
+		);
 	});
 
 	it("should return an error if the bin field is an array", () => {
 		const result = validateBin(["./cli.js"]);
-		expect(result).toEqual([
-			'Type for field "bin" should be `string` or `object`, not `array`',
-		]);
+		expect(result).toEqual(
+			createValidationResult([
+				"type should be `string` or `object`, not `array`",
+			]),
+		);
 	});
 
-	it("should return an error if the bin field is null", () => {
+	it("should return a Result with an issue if the bin field is null", () => {
 		const result = validateBin(null);
-		expect(result).toEqual([
-			"bin field is `null`, but should be a `string` or an `object`",
-		]);
+		expect(result).toEqual(
+			createValidationResult([
+				"field is `null`, but should be a `string` or an `object`",
+			]),
+		);
 	});
 });

--- a/src/validators/validateBin.ts
+++ b/src/validators/validateBin.ts
@@ -1,3 +1,10 @@
+import {
+	addChildResult,
+	addIssue,
+	createValidationResult,
+	type Result,
+} from "../Result.ts";
+
 /**
  * Validate the `bin` field in a package.json, which can either be a string
  * with the path to the executable, or a Record&lt;string, string&gt; where the
@@ -8,42 +15,50 @@
  *   "my-dev-tool" : "./dev-tool.js",
  * }
  */
-export const validateBin = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateBin = (obj: unknown): Result => {
+	const result = createValidationResult();
 
 	if (typeof obj === "string") {
 		if (obj.trim() === "") {
-			errors.push(`bin field is empty, but should be a relative path`);
+			addIssue(result, `field is empty, but should be a relative path`);
 		}
 	} else if (obj && typeof obj === "object" && !Array.isArray(obj)) {
 		let propertyNumber = 0;
 		for (const [key, value] of Object.entries(obj)) {
+			const childResult = createValidationResult();
 			const normalizedKey = key.trim();
 			const fieldName =
 				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
 
 			if (typeof value !== "string") {
-				errors.push(`bin field ${fieldName} should be a string`);
+				addIssue(childResult, `bin field ${fieldName} should be a string`);
 			} else if (value.trim() === "") {
-				errors.push(
+				addIssue(
+					childResult,
 					`bin field ${fieldName} is empty, but should be a relative path`,
 				);
 			}
 			if (key.trim() === "") {
-				errors.push(
+				addIssue(
+					childResult,
 					`bin field ${fieldName} has an empty key, but should be a valid command name`,
 				);
 			}
+			addChildResult(result, childResult, propertyNumber);
 			propertyNumber++;
 		}
 	} else if (obj == null) {
-		errors.push("bin field is `null`, but should be a `string` or an `object`");
+		addIssue(
+			result,
+			"field is `null`, but should be a `string` or an `object`",
+		);
 	} else {
 		const valueType = Array.isArray(obj) ? "array" : typeof obj;
-		errors.push(
-			`Type for field "bin" should be \`string\` or \`object\`, not \`${valueType}\``,
+		addIssue(
+			result,
+			`type should be \`string\` or \`object\`, not \`${valueType}\``,
 		);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #473
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in https://github.com/JoshuaKGoldberg/package-json-validator/issues/393, this change updates `validateBin` to adopt the new `Result` return type.
