### PR TITLE
fix(validateAuthor): improve result output

### DIFF
--- a/src/utils/validatePeople.test.ts
+++ b/src/utils/validatePeople.test.ts
@@ -147,7 +147,7 @@ describe("validatePeople", () => {
 			url: "http://barneyrubble.tumblr.com/",
 		});
 		expect(result.errorMessages).toEqual(["name should not be empty"]);
-		expect(result.childResults[0].issues.length).toBe(1);
+		expect(result.childResults[1].issues.length).toBe(1);
 
 		result = validatePeople({
 			email: "<b@rubble.com>",
@@ -155,7 +155,7 @@ describe("validatePeople", () => {
 			url: "http://barneyrubble.tumblr.com/",
 		});
 		expect(result.errorMessages).toEqual(["name should not be empty"]);
-		expect(result.childResults[0].issues.length).toBe(1);
+		expect(result.childResults[1].issues.length).toBe(1);
 	});
 
 	it("should report error when not a string or object", () => {

--- a/src/utils/validatePeople.test.ts
+++ b/src/utils/validatePeople.test.ts
@@ -63,7 +63,7 @@ describe("validatePeople", () => {
 
 		const barneyEmailResult = barneyResult.childResults[0];
 		expect(barneyEmailResult.errorMessages).toEqual([
-			"Email not valid: brubble",
+			"email is not valid: brubble",
 		]);
 		expect(barneyEmailResult.issues).toHaveLength(1);
 	});
@@ -90,7 +90,9 @@ describe("validatePeople", () => {
 		expect(barneyResult.childResults).toHaveLength(3);
 
 		const barneyUrlResult = barneyResult.childResults[2];
-		expect(barneyUrlResult.errorMessages).toEqual(["URL not valid: not a url"]);
+		expect(barneyUrlResult.errorMessages).toEqual([
+			"url is not valid: not a url",
+		]);
 		expect(barneyUrlResult.issues).toHaveLength(1);
 	});
 
@@ -116,7 +118,9 @@ describe("validatePeople", () => {
 		expect(barneyResult.childResults).toHaveLength(3);
 
 		const barneyUrlResult = barneyResult.childResults[2];
-		expect(barneyUrlResult.errorMessages).toEqual(["URL not valid: not a url"]);
+		expect(barneyUrlResult.errorMessages).toEqual([
+			"url is not valid: not a url",
+		]);
 		expect(barneyUrlResult.issues).toHaveLength(1);
 	});
 
@@ -124,7 +128,7 @@ describe("validatePeople", () => {
 		let result = validatePeople(
 			"<b@rubble.com> (http://barneyrubble.tumblr.com/)",
 		);
-		expect(result.errorMessages).toEqual(["person object should have name"]);
+		expect(result.errorMessages).toEqual(["person should have a name"]);
 		expect(result.issues.length).toBe(1);
 
 		// @ts-expect-error testing invalid param
@@ -132,8 +136,26 @@ describe("validatePeople", () => {
 			email: "<b@rubble.com>",
 			url: "http://barneyrubble.tumblr.com/",
 		});
-		expect(result.errorMessages).toEqual(["person object should have name"]);
+		expect(result.errorMessages).toEqual(["person should have a name"]);
 		expect(result.issues.length).toBe(1);
+	});
+
+	it("should require non-empty name", () => {
+		let result = validatePeople({
+			name: "",
+			email: "<b@rubble.com>",
+			url: "http://barneyrubble.tumblr.com/",
+		});
+		expect(result.errorMessages).toEqual(["name should not be empty"]);
+		expect(result.childResults[0].issues.length).toBe(1);
+
+		result = validatePeople({
+			name: "     ",
+			email: "<b@rubble.com>",
+			url: "http://barneyrubble.tumblr.com/",
+		});
+		expect(result.errorMessages).toEqual(["name should not be empty"]);
+		expect(result.childResults[0].issues.length).toBe(1);
 	});
 
 	it("should report error when not a string or object", () => {

--- a/src/utils/validatePeople.test.ts
+++ b/src/utils/validatePeople.test.ts
@@ -142,16 +142,16 @@ describe("validatePeople", () => {
 
 	it("should require non-empty name", () => {
 		let result = validatePeople({
-			name: "",
 			email: "<b@rubble.com>",
+			name: "",
 			url: "http://barneyrubble.tumblr.com/",
 		});
 		expect(result.errorMessages).toEqual(["name should not be empty"]);
 		expect(result.childResults[0].issues.length).toBe(1);
 
 		result = validatePeople({
-			name: "     ",
 			email: "<b@rubble.com>",
+			name: "     ",
 			url: "http://barneyrubble.tumblr.com/",
 		});
 		expect(result.errorMessages).toEqual(["name should not be empty"]);

--- a/src/utils/validatePeople.ts
+++ b/src/utils/validatePeople.ts
@@ -35,21 +35,24 @@ function validatePerson(obj: Person | string): Result {
 			result = flattenResult(objResult);
 		}
 	} else if (typeof obj == "object") {
-		if (!obj.name) {
-			addIssue(result, "person object should have name");
+		if (typeof obj.name === "undefined") {
+			addIssue(result, "person should have a name");
 		}
 		const entries = Object.entries(obj);
 		for (let i = 0; i < entries.length; i++) {
 			const [key, value] = entries[i];
 			const childResult = createValidationResult();
+			if (key === "name" && typeof value === "string" && value.trim() === "") {
+				addIssue(childResult, `name should not be empty`);
+			}
 			if (key === "email" && value && !emailFormat.test(value)) {
-				addIssue(childResult, `Email not valid: ${value}`);
+				addIssue(childResult, `email is not valid: ${value}`);
 			}
 			if (key === "url" && value && !urlFormat.test(value)) {
-				addIssue(childResult, `URL not valid: ${value}`);
+				addIssue(childResult, `url is not valid: ${value}`);
 			}
 			if (key === "web" && value && !urlFormat.test(value)) {
-				addIssue(childResult, `URL not valid: ${value}`);
+				addIssue(childResult, `url is not valid: ${value}`);
 			}
 			addChildResult(result, childResult, i);
 		}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change is a fast follow, to improve the result output.  After starting to incorporate this into `eslint-plugin-package-json`, there were a few tweaks I wanted to make for how `name` issues are reported. Specifically:
- missing names in author _strings_ were reported as "person object..."
- person objects that had empty string names were not being reported at the name level, but instead being reported the same as if the name was missing entirely (at the top / object level).

This addresses both of those issues, and generally tidies up some of the grammar.
