### PR TITLE
feat(validateBundleDependencies): adopt new Result return type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ It takes the value, and validates it against the following criteria.
 - the property is either an array or a boolean
 - if it's an array, all items should be strings
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -259,7 +259,7 @@ const packageData = {
 	bundleDependencies: ["renderized", "super-streams"],
 };
 
-const errors = validateBundleDependencies(packageData.bundleDependencies);
+const result = validateBundleDependencies(packageData.bundleDependencies);
 ```
 
 ### validateConfig(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -328,6 +328,8 @@ describe("validate", () => {
 		describe("Dependencies Ranges", () => {
 			test("Smoke", () => {
 				const json = getPackageJson({
+					bundledDependencies: ["dep1", "dep2"],
+					bundleDependencies: true,
 					dependencies: {
 						"caret-first": "^1.0.0",
 						"caret-top": "^1",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -38,10 +38,10 @@ const getSpecMap = (
 			bin: { validate: (_, value) => validateBin(value).errorMessages },
 			bugs: { validate: validateUrlOrMailto, warning: true },
 			bundledDependencies: {
-				validate: (_, value) => validateBundleDependencies(value),
+				validate: (_, value) => validateBundleDependencies(value).errorMessages,
 			},
 			bundleDependencies: {
-				validate: (_, value) => validateBundleDependencies(value),
+				validate: (_, value) => validateBundleDependencies(value).errorMessages,
 			},
 			config: { validate: (_, value) => validateConfig(value) },
 			contributors: {

--- a/src/validators/validateBundleDependencies.test.ts
+++ b/src/validators/validateBundleDependencies.test.ts
@@ -1,70 +1,86 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateBundleDependencies } from "./validateBundleDependencies.ts";
 
 describe("validateBundleDependencies", () => {
-	it("should return no errors if the value is an empty array", () => {
+	it("should return a result with no issues if the value is an empty array", () => {
 		const result = validateBundleDependencies([]);
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a valid array with all strings", () => {
+	it("should return a result with no issues if the value is a valid array with all strings", () => {
 		const result = validateBundleDependencies(["nin", "thee-silver-mt-zion"]);
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a boolean", () => {
+	it("should return a result with no issues if the value is a boolean", () => {
 		let result = validateBundleDependencies(true);
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 
 		result = validateBundleDependencies(false);
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return errors if the value is an array with some non-string values", () => {
+	it("should return a result with issues if the value is an array with some non-string values", () => {
 		const result = validateBundleDependencies([
 			"nin",
 			null,
 			"thee-silver-mt-zion",
 			123,
 		]);
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+		]);
+		expect(result.childResults[3].errorMessages).toEqual([
 			"item at index 3 should be a string, not `number`",
 		]);
 	});
 
-	it("should return an error if the value is an array with non-empty strings", () => {
+	it("should return a result with issues if the value is an array with non-empty strings", () => {
 		const result = validateBundleDependencies([
 			"",
 			"nin",
 			"",
 			"thee-silver-mt-zion",
 		]);
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"item at index 0 is empty, but should be a dependency name",
+			"item at index 2 is empty, but should be a dependency name",
+		]);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"item at index 0 is empty, but should be a dependency name",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
 			"item at index 2 is empty, but should be a dependency name",
 		]);
 	});
 
-	it("should return an error if the value is a number", () => {
+	it("should return a result with issues if the value is a number", () => {
 		const result = validateBundleDependencies(123);
-		expect(result).toEqual([
-			"the type should be `Array` or `boolean`, not `number`",
-		]);
+		expect(result).toEqual(
+			new Result(["the type should be `Array` or `boolean`, not `number`"]),
+		);
 	});
 
-	it("should return an error if the value is an object", () => {
+	it("should return a result with issues if the value is an object", () => {
 		const result = validateBundleDependencies({});
-		expect(result).toEqual([
-			"the type should be `Array` or `boolean`, not `object`",
+		expect(result.issues).toEqual([
+			{ message: "the type should be `Array` or `boolean`, not `object`" },
 		]);
 	});
 
-	it("should return an error if the value is null", () => {
+	it("should return a result with issues if the value is null", () => {
 		const result = validateBundleDependencies(null);
-		expect(result).toEqual([
-			"the field is `null`, but should be an `Array` or a `boolean`",
+		expect(result.issues).toEqual([
+			{
+				message: "the value is `null`, but should be an `Array` or a `boolean`",
+			},
 		]);
 	});
 });

--- a/src/validators/validateBundleDependencies.ts
+++ b/src/validators/validateBundleDependencies.ts
@@ -1,37 +1,43 @@
+import { ChildResult, Result } from "../Result.ts";
+
 /**
  * Validate the `bundleDependencies` field in a package.json, which can either be
  * an array of strings or a boolean.
  *
  * ["renderized", "super-streams"]
  */
-export const validateBundleDependencies = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateBundleDependencies = (obj: unknown): Result => {
+	const result = new Result();
 
 	if (typeof obj === "boolean") {
-		return []; // No errors for boolean, as per spec
+		return result; // No errors for boolean, as per spec
 	} else if (Array.isArray(obj)) {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
 			const item = obj[i];
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;
-				errors.push(
+				childResult.addIssue(
 					`item at index ${i} should be a string, not \`${itemType}\``,
 				);
 			} else if (item.trim() === "") {
-				errors.push(
+				childResult.addIssue(
 					`item at index ${i} is empty, but should be a dependency name`,
 				);
 			}
+			result.addChildResult(childResult);
 		}
 	} else if (obj == null) {
-		errors.push("the field is `null`, but should be an `Array` or a `boolean`");
+		result.addIssue(
+			"the value is `null`, but should be an `Array` or a `boolean`",
+		);
 	} else {
 		const valueType = typeof obj;
-		errors.push(
+		result.addIssue(
 			`the type should be \`Array\` or \`boolean\`, not \`${valueType}\``,
 		);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #474
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in https://github.com/JoshuaKGoldberg/package-json-validator/issues/393, this change updates `validateBundleDependencies` to adopt the new Result return type.
