### PR TITLE
feat(validateConfig): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ const errors = validateBundleDependencies(packageData.bundleDependencies);
 This function validates the value of the `config` property of a `package.json`.
 It takes the value, and validates that it's an object.
 
-It returns a list of error messages, if a violation is found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -282,7 +282,7 @@ const packageData = {
 	},
 };
 
-const errors = validateScripts(packageData.config);
+const result = validateConfig(packageData.config);
 ```
 
 ### validateCpu(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -5,6 +5,9 @@ import { validate } from "./validate.ts";
 const getPackageJson = (
 	extra: Record<string, unknown> = {},
 ): Record<string, unknown> => ({
+	config: {
+		debug: true,
+	},
 	name: "test-package",
 	version: "0.5.0",
 	...extra,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -43,7 +43,7 @@ const getSpecMap = (
 			bundleDependencies: {
 				validate: (_, value) => validateBundleDependencies(value),
 			},
-			config: { validate: (_, value) => validateConfig(value) },
+			config: { validate: (_, value) => validateConfig(value).errorMessages },
 			contributors: {
 				validate: (_, value) => validatePeople(value).errorMessages,
 			},

--- a/src/validators/validateConfig.test.ts
+++ b/src/validators/validateConfig.test.ts
@@ -1,34 +1,41 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateConfig } from "./validateConfig.ts";
 
 describe("validateConfig", () => {
-	it("should return no errors if the field is an empty object", () => {
+	it("should return a result with no issues if the field is an empty object", () => {
 		const result = validateConfig({});
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the field is an object", () => {
+	it("should return a result with no issues if the field is an object", () => {
 		const result = validateConfig({
 			debug: true,
 			host: "localhost",
 			port: 8080,
 		});
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return an error if the field is an array", () => {
+	it("should return a result with issues if the field is an array", () => {
 		const result = validateConfig(["array", "of", "values"]);
-		expect(result).toEqual(["the type should be `object`, not `array`"]);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `array`",
+		]);
 	});
 
-	it("should return an error if the field is null", () => {
+	it("should return a result with issues if the field is null", () => {
 		const result = validateConfig(null);
-		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
 	});
 
-	it("should return an error if the field is a string", () => {
+	it("should return a result with issues if the field is a string", () => {
 		const result = validateConfig("string");
-		expect(result).toEqual(["the type should be `object`, not `string`"]);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `string`",
+		]);
 	});
 });

--- a/src/validators/validateConfig.ts
+++ b/src/validators/validateConfig.ts
@@ -1,16 +1,18 @@
+import { Result } from "../Result.ts";
+
 /**
  * Validate the `config` field in a package.json. The value
  * should be an object.
  */
-export const validateConfig = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateConfig = (obj: unknown): Result => {
+	const result = new Result();
 
 	if (obj === null) {
-		errors.push("the field is `null`, but should be an `object`");
+		result.addIssue("the value is `null`, but should be an `object`");
 	} else if (typeof obj !== "object" || Array.isArray(obj)) {
 		const valueType = Array.isArray(obj) ? "array" : typeof obj;
-		errors.push(`the type should be \`object\`, not \`${valueType}\``);
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #475
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in https://github.com/JoshuaKGoldberg/package-json-validator/issues/393, this change updates `validateConfig` to adopt the new Result return type.
