### PR TITLE
feat(validateCpu): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ It takes the value, and validates it against the following criteria.
 - the property is an array
 - all items in the array should be non-empty strings
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -304,7 +304,7 @@ const packageData = {
 	cpu: ["x64", "ia32"],
 };
 
-const errors = validateCpu(packageData.cpu);
+const result = validateCpu(packageData.cpu);
 ```
 
 ### validateDependencies(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -8,6 +8,7 @@ const getPackageJson = (
 	config: {
 		debug: true,
 	},
+	cpu: ["x64", "ia32"],
 	name: "test-package",
 	version: "0.5.0",
 	...extra,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -47,7 +47,7 @@ const getSpecMap = (
 			contributors: {
 				validate: (_, value) => validatePeople(value).errorMessages,
 			},
-			cpu: { validate: (_, value) => validateCpu(value) },
+			cpu: { validate: (_, value) => validateCpu(value).errorMessages },
 			dependencies: {
 				recommended: true,
 				validate: (_, value) => validateDependencies(value),

--- a/src/validators/validateCpu.test.ts
+++ b/src/validators/validateCpu.test.ts
@@ -1,48 +1,85 @@
 import { describe, expect, it } from "vitest";
 
+import { ChildResult, Result } from "../Result.ts";
 import { validateCpu } from "./validateCpu.ts";
 
 describe("validateCpu", () => {
-	it("should return no errors if the value is an empty array", () => {
+	it("should return no issues if the value is an empty array", () => {
 		const result = validateCpu([]);
-		expect(result).toEqual([]);
+
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a valid array with all strings", () => {
+	it("should return no issues if the value is a valid array with all strings", () => {
 		const result = validateCpu(["nin", "thee-silver-mt-zion"]);
-		expect(result).toEqual([]);
+
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return errors if the value is an array with some non-string values", () => {
+	it("should return child results with issues if the value is an array with some non-string values", () => {
 		const result = validateCpu(["nin", null, "thee-silver-mt-zion", 123]);
-		expect(result).toEqual([
+
+		expect(result.errorMessages).toEqual([
 			"item at index 1 should be a string, not `null`",
 			"item at index 3 should be a string, not `number`",
 		]);
+		expect(result.childResults).toEqual([
+			new ChildResult(0),
+			new ChildResult(1, ["item at index 1 should be a string, not `null`"]),
+			new ChildResult(2),
+			new ChildResult(3, ["item at index 3 should be a string, not `number`"]),
+		]);
 	});
 
-	it("should return an error if the value is an array with non-empty strings", () => {
+	it("should return child results with issues if the value is an array with non-empty strings", () => {
 		const result = validateCpu(["", "nin", "", "thee-silver-mt-zion"]);
-		expect(result).toEqual([
-			"item at index 0 is empty, but should be the name of a cpu architecture",
-			"item at index 2 is empty, but should be the name of a cpu architecture",
+
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be the name of a CPU architecture",
+			"item at index 2 is empty, but should be the name of a CPU architecture",
+		]);
+		expect(result.childResults).toEqual([
+			new ChildResult(0, [
+				"item at index 0 is empty, but should be the name of a CPU architecture",
+			]),
+			new ChildResult(1),
+			new ChildResult(2, [
+				"item at index 2 is empty, but should be the name of a CPU architecture",
+			]),
+			new ChildResult(3),
 		]);
 	});
 
-	it("should return an error if the value is a number", () => {
+	it("should return an issue if the value is a number", () => {
 		const result = validateCpu(123);
-		expect(result).toEqual(["the type should be `Array`, not `number`"]);
-	});
 
-	it("should return an error if the value is an object", () => {
-		const result = validateCpu({});
-		expect(result).toEqual(["the type should be `Array`, not `object`"]);
-	});
-
-	it("should return an error if the value is null", () => {
-		const result = validateCpu(null);
-		expect(result).toEqual([
-			"the field is `null`, but should be an `Array` of strings",
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `number`",
 		]);
+		expect(result.issues[0].message).toEqual(
+			"the type should be `Array`, not `number`",
+		);
+	});
+
+	it("should return an issue if the value is an object", () => {
+		const result = validateCpu({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `object`",
+		]);
+		expect(result.issues[0].message).toEqual(
+			"the type should be `Array`, not `object`",
+		);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateCpu(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `Array` of strings",
+		]);
+		expect(result.issues[0].message).toEqual(
+			"the value is `null`, but should be an `Array` of strings",
+		);
 	});
 });

--- a/src/validators/validateCpu.ts
+++ b/src/validators/validateCpu.ts
@@ -1,33 +1,38 @@
+import { ChildResult, Result } from "../Result.ts";
+
 /**
  * Validate the `cpu` field in a package.json, which should be an array of
  * strings.
  *
  * ["x64", "ia32"]
  */
-export const validateCpu = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateCpu = (obj: unknown): Result => {
+	const result = new Result();
 
 	if (Array.isArray(obj)) {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
 			const item = obj[i];
+
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;
-				errors.push(
+				childResult.addIssue(
 					`item at index ${i} should be a string, not \`${itemType}\``,
 				);
 			} else if (item.trim() === "") {
-				errors.push(
-					`item at index ${i} is empty, but should be the name of a cpu architecture`,
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be the name of a CPU architecture`,
 				);
 			}
+			result.addChildResult(childResult);
 		}
 	} else if (obj == null) {
-		errors.push("the field is `null`, but should be an `Array` of strings");
+		result.addIssue("the value is `null`, but should be an `Array` of strings");
 	} else {
 		const valueType = typeof obj;
-		errors.push(`the type should be \`Array\`, not \`${valueType}\``);
+		result.addIssue(`the type should be \`Array\`, not \`${valueType}\``);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #476
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateCpu` to adopt the new Result return type.
