### PR TITLE
feat(validateVersion): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ const errors = validateType(packageData.type);
 This function validates the value of the `version` property of a `package.json`.
 It takes the value, and validates it using `semver`, which is the same package that npm uses.
 
-It returns a list of error messages, if a violation is found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -507,7 +507,7 @@ const packageData = {
 	version: "1.2.3",
 };
 
-const errors = validateVersion(packageData.version);
+const result = validateVersion(packageData.version);
 ```
 
 ## Specification

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -98,7 +98,7 @@ const getSpecMap = (
 			type: { recommended: true, validate: (_, value) => validateType(value) },
 			version: {
 				required: !isPrivate,
-				validate: (_, value) => validateVersion(value),
+				validate: (_, value) => validateVersion(value).errorMessages,
 			},
 		};
 	} else if (specName == "commonjs_1.0") {

--- a/src/validators/validateVersion.test.ts
+++ b/src/validators/validateVersion.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateVersion } from "./validateVersion.ts";
 
 describe("validateVersion", () => {
@@ -9,62 +10,80 @@ describe("validateVersion", () => {
 		"0.0.0-experimental-2f0e7e57-20250715",
 		"0.0.0",
 		"1.2.3-rc.1+rev.2",
-	])("should return no errors for valid version '%s'", (version) => {
-		expect(validateVersion(version)).toEqual([]);
+	])("should return no issues for valid version '%s'", (version) => {
+		expect(validateVersion(version)).toEqual(new Result());
 	});
 
-	it("should return error if the value is not a string (number)", () => {
-		expect(validateVersion(123)).toEqual([
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateVersion(123);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `number`",
 		]);
 	});
 
-	it("should return error if the value is not a string (object)", () => {
-		expect(validateVersion({})).toEqual([
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateVersion({});
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `object`",
 		]);
 	});
 
-	it("should return error if the value is not a string (array)", () => {
-		expect(validateVersion([])).toEqual([
+	it("should return an issue if the value is not a string (array)", () => {
+		const result = validateVersion([]);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `Array`",
 		]);
 	});
 
-	it("should return error if value is not a string (boolean)", () => {
-		expect(validateVersion(true)).toEqual([
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateVersion(true);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `boolean`",
 		]);
 	});
 
-	it("should return error if value is not a string (undefined)", () => {
-		expect(validateVersion(undefined)).toEqual([
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateVersion(undefined);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `undefined`",
 		]);
 	});
 
-	it("should return error if value is not a string (null)", () => {
-		expect(validateVersion(null)).toEqual([
-			"the field is `null`, but should be a `string`",
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateVersion(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
 		]);
 	});
 
-	it("should return error if the value is an empty string", () => {
-		expect(validateVersion("")).toEqual([
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateVersion("");
+
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a valid version",
 		]);
 	});
 
-	it("should return error if the value is whitespace only", () => {
-		expect(validateVersion("   ")).toEqual([
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateVersion("   ");
+
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a valid version",
 		]);
 	});
 
 	it.each(["^1.2.3", "~1.2.3", "invalid", "1.2.3.4.5-alpha2", "1.2", "1"])(
-		"should return error for invalid version '%s'",
+		"should return an issue for invalid version '%s'",
 		(version) => {
-			expect(validateVersion(version)).toEqual([
+			const result = validateVersion(version);
+
+			expect(result.errorMessages).toEqual([
 				"the value is not a valid semver version",
 			]);
 		},

--- a/src/validators/validateVersion.ts
+++ b/src/validators/validateVersion.ts
@@ -1,28 +1,27 @@
 import { valid } from "semver";
 
+import { Result } from "../Result.ts";
+
 /**
  * Validate the `version` field in a package.json, using `semver`.
  */
-export const validateVersion = (version: unknown): string[] => {
-	const errors: string[] = [];
+export const validateVersion = (version: unknown): Result => {
+	const result = new Result();
 
 	if (typeof version !== "string") {
 		if (version === null) {
-			errors.push("the field is `null`, but should be a `string`");
+			result.addIssue("the value is `null`, but should be a `string`");
 		} else {
 			const valueType = Array.isArray(version) ? "Array" : typeof version;
-			errors.push(`the type should be a \`string\`, not \`${valueType}\``);
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
 		}
-		return errors;
-	}
-
-	if (version.trim() === "") {
-		errors.push("the value is empty, but should be a valid version");
+	} else if (version.trim() === "") {
+		result.addIssue("the value is empty, but should be a valid version");
 	} else {
 		if (!valid(version)) {
-			errors.push("the value is not a valid semver version");
+			result.addIssue("the value is not a valid semver version");
 		}
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #484
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateVersion` to adopt the new Result return type.
