### PR TITLE
feat(validateType): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ It takes the value, and validates it against the following criteria.
 - the property is a string
 - its value is either `'commonjs'` or `'module'`
 
-It returns an error message, if a violation is found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -488,7 +488,7 @@ const packageData = {
 	type: "module",
 };
 
-const errors = validateType(packageData.type);
+const result = validateType(packageData.type);
 ```
 
 ### validateVersion(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -6,6 +6,7 @@ const getPackageJson = (
 	extra: Record<string, unknown> = {},
 ): Record<string, unknown> => ({
 	name: "test-package",
+	type: "module",
 	version: "0.5.0",
 	...extra,
 });

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -95,7 +95,10 @@ const getSpecMap = (
 				warning: true,
 			},
 			scripts: { validate: (_, value) => validateScripts(value) },
-			type: { recommended: true, validate: (_, value) => validateType(value) },
+			type: {
+				recommended: true,
+				validate: (_, value) => validateType(value).errorMessages,
+			},
 			version: {
 				required: !isPrivate,
 				validate: (_, value) => validateVersion(value),

--- a/src/validators/validateType.test.ts
+++ b/src/validators/validateType.test.ts
@@ -1,78 +1,101 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateType } from "./validateType.ts";
 
 describe("validateType", () => {
 	it.each(["commonjs", "module"])(
-		"should return no errors for valid type '%s'",
+		"should return no issues for valid type '%s'",
 		(type) => {
-			expect(validateType(type)).toEqual([]);
+			expect(validateType(type)).toEqual(new Result());
 		},
 	);
 
-	it("should return error if type is not a string (number)", () => {
-		expect(validateType(123)).toEqual([
-			"type should be a `string`, not `number`",
+	it("should return an issue if type is not a string (number)", () => {
+		const result = validateType(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `number`",
 		]);
 	});
 
 	it("should return error if type is not a string (object)", () => {
-		expect(validateType({})).toEqual([
-			"type should be a `string`, not `object`",
+		const result = validateType({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `object`",
 		]);
 	});
 
 	it("should return error if type is not a string (array)", () => {
-		expect(validateType([])).toEqual([
-			"type should be a `string`, not `array`",
+		const result = validateType([]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `array`",
 		]);
 	});
 
 	it("should return error if type is not a string (boolean)", () => {
-		expect(validateType(true)).toEqual([
-			"type should be a `string`, not `boolean`",
+		const result = validateType(true);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `boolean`",
 		]);
 	});
 
 	it("should return error if type is not a string (undefined)", () => {
-		expect(validateType(undefined)).toEqual([
-			"type should be a `string`, not `undefined`",
+		const result = validateType(undefined);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `undefined`",
 		]);
 	});
 
 	it("should return error if type is not a string (null)", () => {
-		expect(validateType(null)).toEqual([
-			"type is `null`, but should be a `string`",
+		const result = validateType(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
 		]);
 	});
 
 	it("should return error if type is an empty string", () => {
-		expect(validateType("")).toEqual([
-			"type is empty, but should be one of: commonjs, module",
+		const result = validateType("");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be one of: commonjs, module",
 		]);
 	});
 
 	it("should return error if type is whitespace only", () => {
-		expect(validateType("   ")).toEqual([
-			"type is empty, but should be one of: commonjs, module",
+		const result = validateType("   ");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be one of: commonjs, module",
 		]);
 	});
 
 	it("should return error if type is an invalid string", () => {
-		expect(validateType("esm")).toEqual([
-			'type "esm" is not valid. Valid types are: commonjs, module',
+		const result = validateType("esm");
+
+		expect(result.errorMessages).toEqual([
+			'the value "esm" is not valid. Valid types are: commonjs, module',
 		]);
 	});
 
 	it("should return error if type is a valid type but with extra whitespace", () => {
-		expect(validateType(" commonjs ")).toEqual([
-			'type " commonjs " is not valid. Valid types are: commonjs, module',
+		const result = validateType(" commonjs ");
+
+		expect(result.errorMessages).toEqual([
+			'the value " commonjs " is not valid. Valid types are: commonjs, module',
 		]);
 	});
 
 	it("should return error if type is a case-mismatched valid type", () => {
-		expect(validateType("CommonJS")).toEqual([
-			'type "CommonJS" is not valid. Valid types are: commonjs, module',
+		const result = validateType("CommonJS");
+
+		expect(result.errorMessages).toEqual([
+			'the value "CommonJS" is not valid. Valid types are: commonjs, module',
 		]);
 	});
 });

--- a/src/validators/validateType.ts
+++ b/src/validators/validateType.ts
@@ -1,31 +1,30 @@
+import { Result } from "../Result.ts";
+
 const VALID_TYPES = ["commonjs", "module"];
 
 /**
  * Validate the `type` field in a package.json, which can only be one of the
  * following values: "commonjs" or "module".
  */
-export const validateType = (type: unknown): string[] => {
-	const errors: string[] = [];
+export const validateType = (type: unknown): Result => {
+	const result = new Result();
 
 	if (typeof type !== "string") {
 		if (type === null) {
-			errors.push("type is `null`, but should be a `string`");
+			result.addIssue("the value is `null`, but should be a `string`");
 		} else {
 			const valueType = Array.isArray(type) ? "array" : typeof type;
-			errors.push(`type should be a \`string\`, not \`${valueType}\``);
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
 		}
-		return errors;
-	}
-
-	if (type.trim() === "") {
-		errors.push(
-			`type is empty, but should be one of: ${VALID_TYPES.join(", ")}`,
+	} else if (type.trim() === "") {
+		result.addIssue(
+			`the value is empty, but should be one of: ${VALID_TYPES.join(", ")}`,
 		);
 	} else if (!VALID_TYPES.includes(type)) {
-		errors.push(
-			`type "${type}" is not valid. Valid types are: ${VALID_TYPES.join(", ")}`,
+		result.addIssue(
+			`the value "${type}" is not valid. Valid types are: ${VALID_TYPES.join(", ")}`,
 		);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #483
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateType` to adopt the new Result return type.
