### PR TITLE
feat(validateDescription): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,8 +338,9 @@ const errors = validateBin(packageData.dependencies);
 
 ### validateDescription(value)
 
-This function validates the value of the `description` property of a `package.json`.
-It checks that the value is a non-empty string, and returns a list of error messages, if a violation is found.
+This function validates the value of the `description` property of a `package.json`, checking that the value is a non-empty string.
+
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -350,7 +351,7 @@ const packageData = {
 	description: "The Fragile",
 };
 
-const errors = validateDescription(packageData.description);
+const result = validateDescription(packageData.description);
 ```
 
 ### validateDirectories(value)

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -53,7 +53,7 @@ const getSpecMap = (
 				validate: (_, value) => validateDependencies(value),
 			},
 			description: {
-				validate: (_, value) => validateDescription(value),
+				validate: (_, value) => validateDescription(value).errorMessages,
 				warning: true,
 			},
 			devDependencies: { validate: (_, value) => validateDependencies(value) },

--- a/src/validators/validateDescription.test.ts
+++ b/src/validators/validateDescription.test.ts
@@ -1,56 +1,75 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateDescription } from "./validateDescription.ts";
 
 describe("validateDescription", () => {
-	it("should return no errors for a string", () => {
-		expect(validateDescription("The Fragile")).toEqual([]);
+	it("should return no issues for a string", () => {
+		const result = validateDescription("The Fragile");
+
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return error if the value is not a string (number)", () => {
-		expect(validateDescription(123)).toEqual([
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateDescription(123);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `number`",
 		]);
 	});
 
-	it("should return error if the value is not a string (object)", () => {
-		expect(validateDescription({})).toEqual([
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateDescription({});
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `object`",
 		]);
 	});
 
-	it("should return error if the value is not a string (Array)", () => {
-		expect(validateDescription([])).toEqual([
+	it("should return an issue if the value is not a string (Array)", () => {
+		const result = validateDescription([]);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `Array`",
 		]);
 	});
 
-	it("should return error if value is not a string (boolean)", () => {
-		expect(validateDescription(true)).toEqual([
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateDescription(true);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `boolean`",
 		]);
 	});
 
-	it("should return error if value is not a string (undefined)", () => {
-		expect(validateDescription(undefined)).toEqual([
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateDescription(undefined);
+
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `undefined`",
 		]);
 	});
 
-	it("should return error if value is not a string (null)", () => {
-		expect(validateDescription(null)).toEqual([
-			"the field is `null`, but should be a `string`",
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateDescription(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
 		]);
 	});
 
-	it("should return error if the value is an empty string", () => {
-		expect(validateDescription("")).toEqual([
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateDescription("");
+
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a description",
 		]);
 	});
 
-	it("should return error if the value is whitespace only", () => {
-		expect(validateDescription("   ")).toEqual([
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateDescription("   ");
+
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a description",
 		]);
 	});

--- a/src/validators/validateDescription.ts
+++ b/src/validators/validateDescription.ts
@@ -1,20 +1,22 @@
+import { Result } from "../Result.ts";
+
 /**
  * Validate the `description` field in a package.json.
  * It should be a non-empty string..
  */
-export const validateDescription = (value: unknown): string[] => {
-	const errors: string[] = [];
+export const validateDescription = (value: unknown): Result => {
+	const result = new Result();
 
 	if (typeof value !== "string") {
 		if (value === null) {
-			errors.push("the field is `null`, but should be a `string`");
+			result.addIssue("the value is `null`, but should be a `string`");
 		} else {
 			const valueType = Array.isArray(value) ? "Array" : typeof value;
-			errors.push(`the type should be a \`string\`, not \`${valueType}\``);
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
 		}
 	} else if (value.trim() === "") {
-		errors.push("the value is empty, but should be a description");
+		result.addIssue("the value is empty, but should be a description");
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #478 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateDescription` to adopt the new Result return type.
