### PR TITLE
feat(validateDependencies): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ They take the value, and validate it against the following criteria.
 - The object should be a record of key value pairs
 - For each property, the key should be a valid package name, and the value should be a valid version
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -333,7 +333,7 @@ const packageData = {
 	},
 };
 
-const errors = validateBin(packageData.dependencies);
+const result = validateDependencies(packageData.dependencies);
 ```
 
 ### validateDescription(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -366,6 +366,14 @@ describe("validate", () => {
 						range: "1.2.3 - 2.3.4",
 						"verion-build": "1.2.3+build2012",
 					},
+					optionalDependencies: {
+						gt: ">1.2.3",
+						gteq: ">=1.2.3",
+						lt: "<1.2.3",
+						lteq: "<=1.2.3",
+						range: "1.2.3 - 2.3.4",
+						"verion-build": "1.2.3+build2012",
+					},
 					peerDependencies: {
 						gt: ">1.2.3",
 						gteq: ">=1.2.3",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -50,13 +50,15 @@ const getSpecMap = (
 			cpu: { validate: (_, value) => validateCpu(value).errorMessages },
 			dependencies: {
 				recommended: true,
-				validate: (_, value) => validateDependencies(value),
+				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			description: {
 				validate: (_, value) => validateDescription(value).errorMessages,
 				warning: true,
 			},
-			devDependencies: { validate: (_, value) => validateDependencies(value) },
+			devDependencies: {
+				validate: (_, value) => validateDependencies(value).errorMessages,
+			},
 			directories: {
 				validate: (_, value) => validateDirectories(value).errorMessages,
 			},
@@ -81,11 +83,11 @@ const getSpecMap = (
 				type: "string",
 			},
 			optionalDependencies: {
-				validate: (_, value) => validateDependencies(value),
+				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			os: { type: "array" },
 			peerDependencies: {
-				validate: (_, value) => validateDependencies(value),
+				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			preferGlobal: { type: "boolean" },
 			private: { type: "boolean" },
@@ -124,7 +126,7 @@ const getSpecMap = (
 			cpu: { type: "array" },
 			dependencies: {
 				required: true,
-				validate: (_, value) => validateDependencies(value),
+				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			description: { required: true, type: "string" },
 			directories: { type: "object" },
@@ -170,7 +172,9 @@ const getSpecMap = (
 			},
 
 			cpu: { type: "array" },
-			dependencies: { validate: (_, value) => validateDependencies(value) },
+			dependencies: {
+				validate: (_, value) => validateDependencies(value).errorMessages,
+			},
 			description: { type: "string", warning: true },
 			directories: { required: true, type: "object" },
 			engine: { type: "array" },


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #477
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateDependencies` (and `validateDevDependencies`, `validatePeerDependencies`, `validateOptionalDependencies`) to adopt the new Result return type.
