### PR TITLE
feat(validateDirectories): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ It takes the value, and validates it against the following criteria.
 - its keys are non-empty strings
 - its values are all non-empty strings
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -376,7 +376,7 @@ const packageData = {
 	},
 };
 
-const errors = validateDirectories(packageData.directories);
+const result = validateDirectories(packageData.directories);
 ```
 
 ### validateExports(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -9,6 +9,9 @@ const getPackageJson = (
 		debug: true,
 	},
 	cpu: ["x64", "ia32"],
+	directories: {
+		bin: "dist/bin",
+	},
 	name: "test-package",
 	type: "module",
 	version: "0.5.0",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -57,7 +57,9 @@ const getSpecMap = (
 				warning: true,
 			},
 			devDependencies: { validate: (_, value) => validateDependencies(value) },
-			directories: { validate: (_, value) => validateDirectories(value) },
+			directories: {
+				validate: (_, value) => validateDirectories(value).errorMessages,
+			},
 			engines: { recommended: true, type: "object" },
 			engineStrict: { type: "boolean" },
 			exports: { validate: (_, value) => validateExports(value) },

--- a/src/validators/validateDirectories.test.ts
+++ b/src/validators/validateDirectories.test.ts
@@ -1,67 +1,105 @@
 import { describe, expect, it } from "vitest";
 
+import { ChildResult, Result } from "../Result.ts";
 import { validateDirectories } from "./validateDirectories.ts";
 
 describe("validateDirectories", () => {
-	it("should return no errors if the value is an empty object", () => {
+	it("should return no issues if the value is an empty object", () => {
 		const result = validateDirectories({});
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a valid object with all keys having valid strings", () => {
+	it("should return no issues if the value is a valid object with all keys having valid strings", () => {
 		const result = validateDirectories({
 			bin: "dist/bin",
 			man: "docs",
 		});
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return errors if the value is an object with some keys having invalid scripts", () => {
+	it("should return issues if the value is an object with some keys having invalid scripts", () => {
 		const result = validateDirectories({
 			bin: "dist/bin",
 			man: "",
 			test: "    ",
 		});
-		expect(result).toEqual([
-			'the value of field "man" is empty, but should be a path to a directory',
-			'the value of field "test" is empty, but should be a path to a directory',
-		]);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0),
+					new ChildResult(1, [
+						'the value of property "man" is empty, but should be a path to a directory',
+					]),
+					new ChildResult(2, [
+						'the value of property "test" is empty, but should be a path to a directory',
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the value is an object with an empty string key", () => {
+	it("should return issues if the value is an object with an empty string keys", () => {
 		const result = validateDirectories({
 			"": "dist/bin",
 			"  ": "docs",
 			"    ": "",
 		});
-		expect(result).toEqual([
-			"field 0 has an empty key, but should be a path to a directory",
-			"field 1 has an empty key, but should be a path to a directory",
-			"the value of field 2 is empty, but should be a path to a directory",
-			"field 2 has an empty key, but should be a path to a directory",
-		]);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0, [
+						"property 0 has an empty key, but should be a path to a directory",
+					]),
+					new ChildResult(1, [
+						"property 1 has an empty key, but should be a path to a directory",
+					]),
+					new ChildResult(2, [
+						"the value of property 2 is empty, but should be a path to a directory",
+						"property 2 has an empty key, but should be a path to a directory",
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return errors if the value is an object with some keys having non-string values", () => {
+	it("should return issues if the value is an object with some keys having non-string values", () => {
 		const result = validateDirectories({
 			bin: "dist/bin",
 			invalid: 123,
 		});
-		expect(result).toEqual(['the value of field "invalid" should be a string']);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0),
+					new ChildResult(1, [
+						'the value of property "invalid" should be a string',
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the value is neither a string nor an object", () => {
+	it("should return an issue if the value is neither a string nor an object", () => {
 		const result = validateDirectories(123);
-		expect(result).toEqual(["the type should be `object`, not `number`"]);
+		expect(result).toEqual(
+			new Result(["the type should be `object`, not `number`"]),
+		);
 	});
 
-	it("should return an error if the value is an array", () => {
+	it("should return an issue if the value is an array", () => {
 		const result = validateDirectories(["dist/bin", "docs"]);
-		expect(result).toEqual(["the type should be `object`, not `array`"]);
+		expect(result).toEqual(
+			new Result(["the type should be `object`, not `array`"]),
+		);
 	});
 
-	it("should return an error if the value is null", () => {
+	it("should return an issue if the value is null", () => {
 		const result = validateDirectories(null);
-		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
+		expect(result).toEqual(
+			new Result(["the field is `null`, but should be an `object`"]),
+		);
 	});
 });

--- a/src/validators/validateDirectories.ts
+++ b/src/validators/validateDirectories.ts
@@ -1,37 +1,44 @@
+import { ChildResult, Result } from "../Result.ts";
+
 /**
  * Validate the `directories` field in a package.json. The value of
  * should be a Record&lt;string, string&gt;
  */
-export const validateDirectories = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateDirectories = (obj: unknown): Result => {
+	const result = new Result();
 
 	if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-		let propertyNumber = 0;
-		for (const [key, value] of Object.entries(obj)) {
+		const entries = Object.entries(obj);
+		for (let i = 0; i < entries.length; i++) {
+			const childResult = new ChildResult(i);
+			const [key, value] = entries[i];
+
 			const normalizedKey = key.trim();
-			const fieldName =
-				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+			const propertyName =
+				normalizedKey === "" ? String(i) : `"${normalizedKey}"`;
 
 			if (typeof value !== "string") {
-				errors.push(`the value of field ${fieldName} should be a string`);
+				childResult.addIssue(
+					`the value of property ${propertyName} should be a string`,
+				);
 			} else if (value.trim() === "") {
-				errors.push(
-					`the value of field ${fieldName} is empty, but should be a path to a directory`,
+				childResult.addIssue(
+					`the value of property ${propertyName} is empty, but should be a path to a directory`,
 				);
 			}
 			if (key.trim() === "") {
-				errors.push(
-					`field ${fieldName} has an empty key, but should be a path to a directory`,
+				childResult.addIssue(
+					`property ${propertyName} has an empty key, but should be a path to a directory`,
 				);
 			}
-			propertyNumber++;
+			result.addChildResult(childResult);
 		}
 	} else if (obj === null) {
-		errors.push("the field is `null`, but should be an `object`");
+		result.addIssue("the value is `null`, but should be an `object`");
 	} else {
 		const valueType = Array.isArray(obj) ? "array" : typeof obj;
-		errors.push(`the type should be \`object\`, not \`${valueType}\``);
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #479 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateDirectories` to adopt the new Result return type.
