### PR TITLE
feat(validateExports): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ It takes the value, and validates it against the following criteria.
 - If it's a `string`, it should be a path to an entry point.
 - If it's an export condition `object`, its properties should have values that are either a path to an entry point, or another exports condition object.
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -400,11 +400,10 @@ const packageData = {
 	exports: "./index.js",
 };
 
-const errors = validateExports(packageData.exports);
+const result = validateExports(packageData.exports);
 ```
 
 ```ts
-/* eslint-disable perfectionist/sort-objects */
 import { validateExports } from "package-json-validator";
 
 const packageData = {
@@ -420,8 +419,7 @@ const packageData = {
 	},
 };
 
-const errors = validateExports(packageData.exports);
-/* eslint-enable perfectionist/sort-objects */
+const result = validateExports(packageData.exports);
 ```
 
 ### validateLicense(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -12,6 +12,9 @@ const getPackageJson = (
 	directories: {
 		bin: "dist/bin",
 	},
+	exports: {
+		".": "./index.js",
+	},
 	name: "test-package",
 	type: "module",
 	version: "0.5.0",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -62,7 +62,7 @@ const getSpecMap = (
 			},
 			engines: { recommended: true, type: "object" },
 			engineStrict: { type: "boolean" },
-			exports: { validate: (_, value) => validateExports(value) },
+			exports: { validate: (_, value) => validateExports(value).errorMessages },
 			files: { type: "array" },
 			homepage: { format: urlFormat, recommended: true, type: "string" },
 			keywords: { type: "array", warning: true },

--- a/src/validators/validateExports.test.ts
+++ b/src/validators/validateExports.test.ts
@@ -1,29 +1,31 @@
 /* eslint-disable perfectionist/sort-objects */
 import { describe, expect, it } from "vitest";
 
+import { ChildResult, Result } from "../Result.ts";
 import { validateExports } from "./validateExports.ts";
 
 describe("validateExports", () => {
-	it("should return no errors if the value is an empty object", () => {
+	it("should return no issues if the value is an empty object", () => {
 		const result = validateExports({});
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a valid string", () => {
+	it("should return no issues if the value is a valid string", () => {
 		const result = validateExports("./index.js");
-		expect(result).toEqual([]);
+		expect(result).toEqual(new Result());
 	});
 
-	it("should return no errors if the value is a valid object with all keys having valid strings", () => {
+	it("should return no issues if the value is a valid object with all keys having valid strings", () => {
 		const result = validateExports({
 			".": "./index.js",
 			"./secondary": "./secondary.js",
 			"./tertiary": "./tertiary.js",
 		});
-		expect(result).toEqual([]);
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
 	});
 
-	it("should return no errors if the value is a valid object with one level of nesting", () => {
+	it("should return no issues if the value is a valid object with one level of nesting", () => {
 		const result = validateExports({
 			".": {
 				types: "./index.d.mts",
@@ -37,10 +39,11 @@ describe("validateExports", () => {
 			},
 			"./tertiary": "./tertiary.js",
 		});
-		expect(result).toEqual([]);
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
 	});
 
-	it("should return no errors if the value is a valid object with multiple levels of nesting", () => {
+	it("should return no issues if the value is a valid object with multiple levels of nesting", () => {
 		const result = validateExports({
 			".": {
 				import: {
@@ -59,75 +62,128 @@ describe("validateExports", () => {
 			},
 			"./tertiary": "./tertiary.js",
 		});
-		expect(result).toEqual([]);
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
 	});
 
-	it("should return errors if the value is an object with some properties having invalid string", () => {
+	it("should return issues if the value is an object with some properties having invalid string", () => {
 		const result = validateExports({
 			".": "./index.js",
 			"./secondary": "",
 			"./tertiary": "    ",
 		});
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			'the value of "./secondary" is empty, but should be an entry point path',
 			'the value of "./tertiary" is empty, but should be an entry point path',
 		]);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0),
+					new ChildResult(1, [
+						'the value of "./secondary" is empty, but should be an entry point path',
+					]),
+					new ChildResult(2, [
+						'the value of "./tertiary" is empty, but should be an entry point path',
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the value is an object with an empty string key", () => {
+	it("should return issues if the value is an object with empty string keys", () => {
 		const result = validateExports({
 			"": "./index.js",
 			"  ": "./secondary.ks",
 			"    ": "",
 		});
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"property 0 has an empty key, but should be an export condition",
 			"property 1 has an empty key, but should be an export condition",
-			"property 2 has an empty key, but should be an export condition",
 			"the value of property 2 is empty, but should be an entry point path",
+			"property 2 has an empty key, but should be an export condition",
 		]);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0, [
+						"property 0 has an empty key, but should be an export condition",
+					]),
+					new ChildResult(1, [
+						"property 1 has an empty key, but should be an export condition",
+					]),
+					new ChildResult(2, [
+						"the value of property 2 is empty, but should be an entry point path",
+						"property 2 has an empty key, but should be an export condition",
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return errors if the value is an object with some keys having invalid values", () => {
+	it("should return issues if the value is an object with some keys having invalid values", () => {
 		const result = validateExports({
 			".": "./index.js",
 			"invalid-number": 123,
 			"invalid-null": null,
 			"invalid-array": [],
 		});
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			'the value of "invalid-number" should be either an entry point path or an object of export conditions',
 			'the value of "invalid-null" should be either an entry point path or an object of export conditions',
 			'the value of "invalid-array" should be either an entry point path or an object of export conditions',
 		]);
+		expect(result).toEqual(
+			new Result(
+				[],
+				[
+					new ChildResult(0),
+					new ChildResult(1, [
+						'the value of "invalid-number" should be either an entry point path or an object of export conditions',
+					]),
+					new ChildResult(2, [
+						'the value of "invalid-null" should be either an entry point path or an object of export conditions',
+					]),
+					new ChildResult(3, [
+						'the value of "invalid-array" should be either an entry point path or an object of export conditions',
+					]),
+				],
+			),
+		);
 	});
 
-	it("should return an error if the value is an empty string", () => {
+	it("should return an issue if the value is an empty string", () => {
 		const result = validateExports("");
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be an entry point path",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return an error if the value is neither a string nor an object", () => {
+	it("should return an issue if the value is neither a string nor an object", () => {
 		const result = validateExports(123);
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"the type should be `object` or `string`, not `number`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return an error if the scripts field is an array", () => {
+	it("should return an issue if the scripts field is an array", () => {
 		const result = validateExports(["./index.js", "./secondary.js"]);
-		expect(result).toEqual([
+		expect(result.errorMessages).toEqual([
 			"the type should be `object` or `string`, not `Array`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return an error if the scripts field is null", () => {
+	it("should return an issue if the scripts field is null", () => {
 		const result = validateExports(null);
-		expect(result).toEqual([
-			"the field is `null`, but should be an `object` or `string`",
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object` or `string`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 });
 /* eslint-enable perfectionist/sort-objects */


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #480
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateExports` to adopt the new Result return type.
