### PR TITLE
feat(validateLicense): adopt new Result return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ const errors = validateExports(packageData.exports);
 This function validates the value of the `license` property of a `package.json`.
 It takes the value, and validates it using `validate-npm-package-license`, which is the same package that npm uses.
 
-It returns a list of error messages, if a violation is found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -439,7 +439,7 @@ const packageData = {
 	license: "MIT",
 };
 
-const errors = validateLicense(packageData.license);
+const result = validateLicense(packageData.license);
 ```
 
 ### validateScripts(value)

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -64,7 +64,7 @@ const getSpecMap = (
 			files: { type: "array" },
 			homepage: { format: urlFormat, recommended: true, type: "string" },
 			keywords: { type: "array", warning: true },
-			license: { validate: (_, value) => validateLicense(value) },
+			license: { validate: (_, value) => validateLicense(value).errorMessages },
 			licenses: {
 				or: "license",
 				type: "array",

--- a/src/validators/validateLicense.test.ts
+++ b/src/validators/validateLicense.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { Result } from "../Result.ts";
 import { validateLicense } from "./validateLicense.ts";
 
 describe("validateLicense", () => {
@@ -12,59 +13,77 @@ describe("validateLicense", () => {
 		"(GPL-3.0-only OR BSD-2-Clause)",
 		"SEE LICENSE IN license.md",
 		"SEE LICENCE IN license.md",
-	])("should return no errors for valid license '%s'", (license) => {
-		expect(validateLicense(license)).toEqual([]);
+	])("should return no issues for valid license '%s'", (license) => {
+		expect(validateLicense(license)).toEqual(new Result());
 	});
 
-	it("should return error if the value is not a string (number)", () => {
-		expect(validateLicense(123)).toEqual([
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateLicense(123);
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `number`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if the value is not a string (object)", () => {
-		expect(validateLicense({})).toEqual([
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateLicense({});
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `object`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if the value is not a string (array)", () => {
-		expect(validateLicense([])).toEqual([
+	it("should return an issue if the value is not a string (array)", () => {
+		const result = validateLicense([]);
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `Array`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if value is not a string (boolean)", () => {
-		expect(validateLicense(true)).toEqual([
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateLicense(true);
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `boolean`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if value is not a string (undefined)", () => {
-		expect(validateLicense(undefined)).toEqual([
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateLicense(undefined);
+		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `undefined`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if value is not a string (null)", () => {
-		expect(validateLicense(null)).toEqual([
-			"the field is `null`, but should be a `string`",
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateLicense(null);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if the value is an empty string", () => {
-		expect(validateLicense("")).toEqual([
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateLicense("");
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a valid license",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if the value is whitespace only", () => {
-		expect(validateLicense("   ")).toEqual([
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateLicense("   ");
+		expect(result.errorMessages).toEqual([
 			"the value is empty, but should be a valid license",
 		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return error if the value is an invalid string", () => {
-		expect(validateLicense("LicenseRef-Made-Up")).toHaveLength(1);
+	it("should return an issue if the value is an invalid string", () => {
+		const result = validateLicense("LicenseRef-Made-Up");
+		expect(result.errorMessages).toHaveLength(1);
+		expect(result.issues).toHaveLength(1);
 	});
 });

--- a/src/validators/validateLicense.ts
+++ b/src/validators/validateLicense.ts
@@ -1,29 +1,30 @@
 import valid from "validate-npm-package-license";
 
+import { Result } from "../Result.ts";
+
 /**
  * Validate the `license` field in a package.json, using `validate-npm-package-license`.
  */
-export const validateLicense = (license: unknown): string[] => {
-	const errors: string[] = [];
+export const validateLicense = (license: unknown): Result => {
+	const result = new Result();
 
 	if (typeof license !== "string") {
 		if (license === null) {
-			errors.push("the field is `null`, but should be a `string`");
+			result.addIssue("the value is `null`, but should be a `string`");
 		} else {
 			const valueType = Array.isArray(license) ? "Array" : typeof license;
-			errors.push(`the type should be a \`string\`, not \`${valueType}\``);
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
 		}
-		return errors;
-	}
-
-	if (license.trim() === "") {
-		errors.push("the value is empty, but should be a valid license");
+	} else if (license.trim() === "") {
+		result.addIssue("the value is empty, but should be a valid license");
 	} else {
 		const validationResults = valid(license);
 		if (validationResults.warnings) {
-			errors.push(...validationResults.warnings);
+			for (const warning of validationResults.warnings) {
+				result.addIssue(warning);
+			}
 		}
 	}
 
-	return errors;
+	return result;
 };


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #481
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in #393, this change updates `validateLicense` to adopt the new Result return type.
