### PR TITLE
feat(validateScripts): adopt new Result return type 

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ It takes the value, and validates it against the following criteria.
 - its keys are non-empty strings
 - its values are all non-empty strings
 
-It returns a list of error messages, if any violations are found.
+It returns a `Result` object (See [Result Types](#result-types)).
 
 #### Examples
 
@@ -465,7 +465,7 @@ const packageData = {
 	},
 };
 
-const errors = validateScripts(packageData.scripts);
+const result = validateScripts(packageData.scripts);
 ```
 
 ### validateType(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -16,6 +16,9 @@ const getPackageJson = (
 		".": "./index.js",
 	},
 	name: "test-package",
+	scripts: {
+		lint: "eslint .",
+	},
 	type: "module",
 	version: "0.5.0",
 	...extra,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -98,7 +98,7 @@ const getSpecMap = (
 				validate: validateUrlTypes,
 				warning: true,
 			},
-			scripts: { validate: (_, value) => validateScripts(value) },
+			scripts: { validate: (_, value) => validateScripts(value).errorMessages },
 			type: {
 				recommended: true,
 				validate: (_, value) => validateType(value).errorMessages,

--- a/src/validators/validateAuthor.test.ts
+++ b/src/validators/validateAuthor.test.ts
@@ -26,7 +26,7 @@ describe("validateAuthor", () => {
 		expect(mockValidatePeople).toHaveBeenCalledWith(
 			"Barney Rubble <b@rubble.com> (http://barnyrubble.tumblr.com/)",
 		);
-		expect(result).toEqual(mockResult);
+		expect(result).toBe(mockResult);
 	});
 
 	it("should call validatePeople with 'author' and the object if input is a person object", () => {
@@ -44,18 +44,17 @@ describe("validateAuthor", () => {
 		const result = validateAuthor(personObj);
 
 		expect(mockValidatePeople).toHaveBeenCalledWith(personObj);
-		expect(result).toEqual(mockResult);
+		expect(result).toBe(mockResult);
 	});
 
 	it("should return the correct error if input is not a string or person object", () => {
 		vi.mocked(isPerson).mockReturnValue(false);
 
 		const result = validateAuthor(123);
-		expect(result).toEqual(
-			new Result([
-				"the type should be a `string` or an `object` with at least a `name` property",
-			]),
-		);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string` or an `object` with at least a `name` property",
+		]);
 		expect(vi.mocked(validatePeople)).not.toHaveBeenCalled();
 	});
 });

--- a/src/validators/validateBin.test.ts
+++ b/src/validators/validateBin.test.ts
@@ -1,27 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { ChildResult, Result } from "../Result.ts";
 import { validateBin } from "./validateBin.ts";
 
 describe("validateBin", () => {
 	it("should return a Result with no issues if the bin field is an empty object", () => {
 		const result = validateBin({});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it.each(["./cli.js", "cli.js", "./bin/cli.js", "bin/cli.js"])(
 		"should return a Result with no issues if the bin field is a valid string: %s",
 		(binPath) => {
 			const result = validateBin(binPath);
-			expect(result).toEqual(new Result());
+			expect(result.errorMessages).toEqual([]);
 		},
 	);
 
 	it("should return a Result with one issue when the bin field is an empty string", () => {
 		const result = validateBin("");
-		expect(result).toEqual(
-			new Result(["the value is empty, but should be a relative path"]),
-		);
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be a relative path",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return a Result with ChildResults that have no issues if the bin field is a valid object with all keys having valid strings", () => {
@@ -31,17 +31,11 @@ describe("validateBin", () => {
 			"my-other-cli": "bin/cli.js",
 			"my-other-tool": "./tools/other-tool.js",
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0, []),
-					new ChildResult(1, []),
-					new ChildResult(2, []),
-					new ChildResult(3, []),
-				],
-			),
-		);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		result.childResults.forEach((childResult) => {
+			expect(childResult.issues).toHaveLength(0);
+		});
 	});
 
 	it("should return a Result with ChildResults that have issues if the bin field is an object with some keys having invalid paths", () => {
@@ -50,20 +44,15 @@ describe("validateBin", () => {
 			"my-dev-tool": "",
 			"my-other-tool": "  ",
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0, []),
-					new ChildResult(1, [
-						'the value of property "my-dev-tool" is empty, but should be a relative path',
-					]),
-					new ChildResult(2, [
-						'the value of property "my-other-tool" is empty, but should be a relative path',
-					]),
-				],
-			),
-		);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "my-dev-tool" is empty, but should be a relative path',
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			'the value of property "my-other-tool" is empty, but should be a relative path',
+		]);
 	});
 
 	it("should return a Result with ChildResults that have issues if the bin field is an object with an empty string key", () => {
@@ -72,23 +61,18 @@ describe("validateBin", () => {
 			"  ": "./dev-tool.js",
 			"    ": "",
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0, [
-						"property 0 has an empty key, but should be a valid command name",
-					]),
-					new ChildResult(1, [
-						"property 1 has an empty key, but should be a valid command name",
-					]),
-					new ChildResult(2, [
-						"the value of property 2 is empty, but should be a relative path",
-						"property 2 has an empty key, but should be a valid command name",
-					]),
-				],
-			),
-		);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"property 0 has an empty key, but should be a valid command name",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"property 1 has an empty key, but should be a valid command name",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"the value of property 2 is empty, but should be a relative path",
+			"property 2 has an empty key, but should be a valid command name",
+		]);
 	});
 
 	it("should return a Result with ChildResults that have issues if the bin field is an object with some keys having non-string values", () => {
@@ -97,40 +81,36 @@ describe("validateBin", () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			"my-dev-tool": 123 as any,
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0),
-					new ChildResult(1, [
-						'the value of property "my-dev-tool" should be a string',
-					]),
-				],
-			),
-		);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "my-dev-tool" should be a string',
+		]);
 	});
 
 	it("should return a Result with an issue if the bin field is neither a string nor an object", () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const result = validateBin(123 as any);
-		expect(result).toEqual(
-			new Result(["the type should be `string` or `object`, not `number`"]),
-		);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `string` or `object`, not `number`",
+		]);
 	});
 
 	it("should return an error if the bin field is an array", () => {
 		const result = validateBin(["./cli.js"]);
-		expect(result).toEqual(
-			new Result(["the type should be `string` or `object`, not `array`"]),
-		);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `string` or `object`, not `array`",
+		]);
 	});
 
 	it("should return a Result with an issue if the bin field is null", () => {
 		const result = validateBin(null);
-		expect(result).toEqual(
-			new Result([
-				"the value is `null`, but should be a `string` or an `object`",
-			]),
-		);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string` or an `object`",
+		]);
 	});
 });

--- a/src/validators/validateBundleDependencies.test.ts
+++ b/src/validators/validateBundleDependencies.test.ts
@@ -1,25 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { Result } from "../Result.ts";
 import { validateBundleDependencies } from "./validateBundleDependencies.ts";
 
 describe("validateBundleDependencies", () => {
 	it("should return a result with no issues if the value is an empty array", () => {
 		const result = validateBundleDependencies([]);
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return a result with no issues if the value is a valid array with all strings", () => {
 		const result = validateBundleDependencies(["nin", "thee-silver-mt-zion"]);
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return a result with no issues if the value is a boolean", () => {
 		let result = validateBundleDependencies(true);
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 
 		result = validateBundleDependencies(false);
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return a result with issues if the value is an array with some non-string values", () => {
@@ -63,9 +62,10 @@ describe("validateBundleDependencies", () => {
 
 	it("should return a result with issues if the value is a number", () => {
 		const result = validateBundleDependencies(123);
-		expect(result).toEqual(
-			new Result(["the type should be `Array` or `boolean`, not `number`"]),
-		);
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array` or `boolean`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return a result with issues if the value is an object", () => {

--- a/src/validators/validateConfig.test.ts
+++ b/src/validators/validateConfig.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { Result } from "../Result.ts";
 import { validateConfig } from "./validateConfig.ts";
 
 describe("validateConfig", () => {
 	it("should return a result with no issues if the field is an empty object", () => {
 		const result = validateConfig({});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return a result with no issues if the field is an object", () => {
@@ -15,7 +14,7 @@ describe("validateConfig", () => {
 			host: "localhost",
 			port: 8080,
 		});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return a result with issues if the field is an array", () => {

--- a/src/validators/validateCpu.test.ts
+++ b/src/validators/validateCpu.test.ts
@@ -1,19 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { ChildResult, Result } from "../Result.ts";
 import { validateCpu } from "./validateCpu.ts";
 
 describe("validateCpu", () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateCpu([]);
 
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return no issues if the value is a valid array with all strings", () => {
 		const result = validateCpu(["nin", "thee-silver-mt-zion"]);
 
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return child results with issues if the value is an array with some non-string values", () => {
@@ -23,12 +22,12 @@ describe("validateCpu", () => {
 			"item at index 1 should be a string, not `null`",
 			"item at index 3 should be a string, not `number`",
 		]);
-		expect(result.childResults).toEqual([
-			new ChildResult(0),
-			new ChildResult(1, ["item at index 1 should be a string, not `null`"]),
-			new ChildResult(2),
-			new ChildResult(3, ["item at index 3 should be a string, not `number`"]),
-		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].issues).toEqual([]);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[2].issues).toEqual([]);
+		expect(result.childResults[3].issues).toHaveLength(1);
 	});
 
 	it("should return child results with issues if the value is an array with non-empty strings", () => {
@@ -38,16 +37,12 @@ describe("validateCpu", () => {
 			"item at index 0 is empty, but should be the name of a CPU architecture",
 			"item at index 2 is empty, but should be the name of a CPU architecture",
 		]);
-		expect(result.childResults).toEqual([
-			new ChildResult(0, [
-				"item at index 0 is empty, but should be the name of a CPU architecture",
-			]),
-			new ChildResult(1),
-			new ChildResult(2, [
-				"item at index 2 is empty, but should be the name of a CPU architecture",
-			]),
-			new ChildResult(3),
-		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toEqual([]);
+		expect(result.childResults[2].issues).toHaveLength(1);
+		expect(result.childResults[3].issues).toEqual([]);
 	});
 
 	it("should return an issue if the value is a number", () => {
@@ -56,9 +51,7 @@ describe("validateCpu", () => {
 		expect(result.errorMessages).toEqual([
 			"the type should be `Array`, not `number`",
 		]);
-		expect(result.issues[0].message).toEqual(
-			"the type should be `Array`, not `number`",
-		);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return an issue if the value is an object", () => {
@@ -67,9 +60,7 @@ describe("validateCpu", () => {
 		expect(result.errorMessages).toEqual([
 			"the type should be `Array`, not `object`",
 		]);
-		expect(result.issues[0].message).toEqual(
-			"the type should be `Array`, not `object`",
-		);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return an issue if the value is null", () => {
@@ -78,8 +69,6 @@ describe("validateCpu", () => {
 		expect(result.errorMessages).toEqual([
 			"the value is `null`, but should be an `Array` of strings",
 		]);
-		expect(result.issues[0].message).toEqual(
-			"the value is `null`, but should be an `Array` of strings",
-		);
+		expect(result.issues).toHaveLength(1);
 	});
 });

--- a/src/validators/validateDirectories.test.ts
+++ b/src/validators/validateDirectories.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { ChildResult, Result } from "../Result.ts";
 import { validateDirectories } from "./validateDirectories.ts";
 
 describe("validateDirectories", () => {
 	it("should return no issues if the value is an empty object", () => {
 		const result = validateDirectories({});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return no issues if the value is a valid object with all keys having valid strings", () => {
@@ -14,7 +13,7 @@ describe("validateDirectories", () => {
 			bin: "dist/bin",
 			man: "docs",
 		});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return issues if the value is an object with some keys having invalid scripts", () => {
@@ -23,20 +22,19 @@ describe("validateDirectories", () => {
 			man: "",
 			test: "    ",
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0),
-					new ChildResult(1, [
-						'the value of property "man" is empty, but should be a path to a directory',
-					]),
-					new ChildResult(2, [
-						'the value of property "test" is empty, but should be a path to a directory',
-					]),
-				],
-			),
-		);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
+		[
+			[],
+			[
+				'the value of property "man" is empty, but should be a path to a directory',
+			],
+			[
+				'the value of property "test" is empty, but should be a path to a directory',
+			],
+		].forEach((childErrors, index) => {
+			expect(result.childResults[index].errorMessages).toEqual(childErrors);
+		});
 	});
 
 	it("should return issues if the value is an object with an empty string keys", () => {
@@ -45,23 +43,18 @@ describe("validateDirectories", () => {
 			"  ": "docs",
 			"    ": "",
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0, [
-						"property 0 has an empty key, but should be a path to a directory",
-					]),
-					new ChildResult(1, [
-						"property 1 has an empty key, but should be a path to a directory",
-					]),
-					new ChildResult(2, [
-						"the value of property 2 is empty, but should be a path to a directory",
-						"property 2 has an empty key, but should be a path to a directory",
-					]),
-				],
-			),
-		);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
+		[
+			["property 0 has an empty key, but should be a path to a directory"],
+			["property 1 has an empty key, but should be a path to a directory"],
+			[
+				"the value of property 2 is empty, but should be a path to a directory",
+				"property 2 has an empty key, but should be a path to a directory",
+			],
+		].forEach((childErrors, index) => {
+			expect(result.childResults[index].errorMessages).toEqual(childErrors);
+		});
 	});
 
 	it("should return issues if the value is an object with some keys having non-string values", () => {
@@ -69,37 +62,36 @@ describe("validateDirectories", () => {
 			bin: "dist/bin",
 			invalid: 123,
 		});
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0),
-					new ChildResult(1, [
-						'the value of property "invalid" should be a string',
-					]),
-				],
-			),
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(2);
+		[[], ['the value of property "invalid" should be a string']].forEach(
+			(childErrors, index) => {
+				expect(result.childResults[index].errorMessages).toEqual(childErrors);
+			},
 		);
 	});
 
 	it("should return an issue if the value is neither a string nor an object", () => {
 		const result = validateDirectories(123);
-		expect(result).toEqual(
-			new Result(["the type should be `object`, not `number`"]),
-		);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return an issue if the value is an array", () => {
 		const result = validateDirectories(["dist/bin", "docs"]);
-		expect(result).toEqual(
-			new Result(["the type should be `object`, not `array`"]),
-		);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `array`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
 	it("should return an issue if the value is null", () => {
 		const result = validateDirectories(null);
-		expect(result).toEqual(
-			new Result(["the field is `null`, but should be an `object`"]),
-		);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 });

--- a/src/validators/validateExports.test.ts
+++ b/src/validators/validateExports.test.ts
@@ -1,18 +1,17 @@
 /* eslint-disable perfectionist/sort-objects */
 import { describe, expect, it } from "vitest";
 
-import { ChildResult, Result } from "../Result.ts";
 import { validateExports } from "./validateExports.ts";
 
 describe("validateExports", () => {
 	it("should return no issues if the value is an empty object", () => {
 		const result = validateExports({});
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return no issues if the value is a valid string", () => {
 		const result = validateExports("./index.js");
-		expect(result).toEqual(new Result());
+		expect(result.errorMessages).toEqual([]);
 	});
 
 	it("should return no issues if the value is a valid object with all keys having valid strings", () => {
@@ -76,20 +75,17 @@ describe("validateExports", () => {
 			'the value of "./secondary" is empty, but should be an entry point path',
 			'the value of "./tertiary" is empty, but should be an entry point path',
 		]);
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0),
-					new ChildResult(1, [
-						'the value of "./secondary" is empty, but should be an entry point path',
-					]),
-					new ChildResult(2, [
-						'the value of "./tertiary" is empty, but should be an entry point path',
-					]),
-				],
-			),
-		);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
+		[
+			[],
+			[
+				'the value of "./secondary" is empty, but should be an entry point path',
+			],
+			['the value of "./tertiary" is empty, but should be an entry point path'],
+		].forEach((childErrors, i) => {
+			expect(result.childResults[i].errorMessages).toEqual(childErrors);
+		});
 	});
 
 	it("should return issues if the value is an object with empty string keys", () => {
@@ -104,23 +100,18 @@ describe("validateExports", () => {
 			"the value of property 2 is empty, but should be an entry point path",
 			"property 2 has an empty key, but should be an export condition",
 		]);
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0, [
-						"property 0 has an empty key, but should be an export condition",
-					]),
-					new ChildResult(1, [
-						"property 1 has an empty key, but should be an export condition",
-					]),
-					new ChildResult(2, [
-						"the value of property 2 is empty, but should be an entry point path",
-						"property 2 has an empty key, but should be an export condition",
-					]),
-				],
-			),
-		);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
+		[
+			["property 0 has an empty key, but should be an export condition"],
+			["property 1 has an empty key, but should be an export condition"],
+			[
+				"the value of property 2 is empty, but should be an entry point path",
+				"property 2 has an empty key, but should be an export condition",
+			],
+		].forEach((childErrors, i) => {
+			expect(result.childResults[i].errorMessages).toEqual(childErrors);
+		});
 	});
 
 	it("should return issues if the value is an object with some keys having invalid values", () => {
@@ -135,23 +126,22 @@ describe("validateExports", () => {
 			'the value of "invalid-null" should be either an entry point path or an object of export conditions',
 			'the value of "invalid-array" should be either an entry point path or an object of export conditions',
 		]);
-		expect(result).toEqual(
-			new Result(
-				[],
-				[
-					new ChildResult(0),
-					new ChildResult(1, [
-						'the value of "invalid-number" should be either an entry point path or an object of export conditions',
-					]),
-					new ChildResult(2, [
-						'the value of "invalid-null" should be either an entry point path or an object of export conditions',
-					]),
-					new ChildResult(3, [
-						'the value of "invalid-array" should be either an entry point path or an object of export conditions',
-					]),
-				],
-			),
-		);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults).toHaveLength(4);
+		[
+			[],
+			[
+				'the value of "invalid-number" should be either an entry point path or an object of export conditions',
+			],
+			[
+				'the value of "invalid-null" should be either an entry point path or an object of export conditions',
+			],
+			[
+				'the value of "invalid-array" should be either an entry point path or an object of export conditions',
+			],
+		].forEach((childErrors, i) => {
+			expect(result.childResults[i].errorMessages).toEqual(childErrors);
+		});
 	});
 
 	it("should return an issue if the value is an empty string", () => {

--- a/src/validators/validateLicense.test.ts
+++ b/src/validators/validateLicense.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { Result } from "../Result.ts";
 import { validateLicense } from "./validateLicense.ts";
 
 describe("validateLicense", () => {
@@ -14,7 +13,7 @@ describe("validateLicense", () => {
 		"SEE LICENSE IN license.md",
 		"SEE LICENCE IN license.md",
 	])("should return no issues for valid license '%s'", (license) => {
-		expect(validateLicense(license)).toEqual(new Result());
+		expect(validateLicense(license).errorMessages).toEqual([]);
 	});
 
 	it("should return an issue if the value is not a string (number)", () => {

--- a/src/validators/validateScripts.test.ts
+++ b/src/validators/validateScripts.test.ts
@@ -3,66 +3,104 @@ import { describe, expect, it } from "vitest";
 import { validateScripts } from "./validateScripts.ts";
 
 describe("validateScripts", () => {
-	it("should return no errors if the scripts field is an empty object", () => {
+	it("should return no issues if the scripts field is an empty object", () => {
 		const result = validateScripts({});
-		expect(result).toEqual([]);
+		expect(result.errorMessages).toEqual([]);
 	});
 
-	it("should return no errors if the scripts field is a valid object with all keys having valid strings", () => {
+	it("should return no issues if the scripts field is a valid object with all keys having valid strings", () => {
 		const result = validateScripts({
 			build: "rollup -c",
 			lint: "eslint .",
 			test: "vitest",
 		});
-		expect(result).toEqual([]);
+		expect(result.errorMessages).toEqual([]);
 	});
 
-	it("should return errors if the scripts field is an object with some keys having invalid scripts", () => {
+	it("should return issues if the scripts field is an object with some keys having invalid scripts", () => {
 		const result = validateScripts({
 			build: "rollup -c",
 			lint: "",
 			test: "    ",
 		});
-		expect(result).toEqual([
-			'the value of field "lint" is empty, but should be a script command',
-			'the value of field "test" is empty, but should be a script command',
+		expect(result.errorMessages).toEqual([
+			'the value of property "lint" is empty, but should be a script command',
+			'the value of property "test" is empty, but should be a script command',
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "lint" is empty, but should be a script command',
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			'the value of property "test" is empty, but should be a script command',
 		]);
 	});
 
-	it("should return an error if the scripts field is an object with an empty string key", () => {
+	it("should return issues if the scripts field is an object with empty string keys", () => {
 		const result = validateScripts({
 			"": "rollup -c",
 			"  ": "eslint .",
 			"    ": "",
 		});
-		expect(result).toEqual([
-			"field 0 has an empty key, but should be a script name",
-			"field 1 has an empty key, but should be a script name",
-			"the value of field 2 is empty, but should be a script command",
-			"field 2 has an empty key, but should be a script name",
+		expect(result.errorMessages).toEqual([
+			"property 0 has an empty key, but should be a script name",
+			"property 1 has an empty key, but should be a script name",
+			"the value of property 2 is empty, but should be a script command",
+			"property 2 has an empty key, but should be a script name",
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"property 0 has an empty key, but should be a script name",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"property 1 has an empty key, but should be a script name",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"the value of property 2 is empty, but should be a script command",
+			"property 2 has an empty key, but should be a script name",
 		]);
 	});
 
-	it("should return errors if the scripts field is an object with some keys having non-string values", () => {
+	it("should return issues if the scripts field is an object with some keys having non-string values", () => {
 		const result = validateScripts({
 			build: "rollup -c",
 			invalid: 123,
 		});
-		expect(result).toEqual(['the value of field "invalid" should be a string']);
+		expect(result.errorMessages).toEqual([
+			'the value of property "invalid" should be a string',
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "invalid" should be a string',
+		]);
 	});
 
-	it("should return an error if the scripts field is neither a string nor an object", () => {
+	it("should return an issue if the scripts field is neither a string nor an object", () => {
 		const result = validateScripts(123);
-		expect(result).toEqual(["the type should be `object`, not `number`"]);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return an error if the scripts field is an array", () => {
+	it("should return an issue if the scripts field is an array", () => {
 		const result = validateScripts(["rollup -c", "eslint ."]);
-		expect(result).toEqual(["the type should be `object`, not `array`"]);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `array`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 
-	it("should return an error if the scripts field is null", () => {
+	it("should return an issue if the scripts field is null", () => {
 		const result = validateScripts(null);
-		expect(result).toEqual(["the field is `null`, but should be an `object`"]);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
+		expect(result.issues).toHaveLength(1);
 	});
 });

--- a/src/validators/validateScripts.ts
+++ b/src/validators/validateScripts.ts
@@ -1,37 +1,44 @@
+import { ChildResult, Result } from "../Result.ts";
+
 /**
  * Validate the `scripts` field in a package.json. The value of
  * should be a Record&lt;string, string&gt;
  */
-export const validateScripts = (obj: unknown): string[] => {
-	const errors: string[] = [];
+export const validateScripts = (obj: unknown): Result => {
+	const result = new Result();
 
 	if (obj && typeof obj === "object" && !Array.isArray(obj)) {
-		let propertyNumber = 0;
-		for (const [key, value] of Object.entries(obj)) {
+		const entries = Object.entries(obj);
+		for (let i = 0; i < entries.length; i++) {
+			const childResult = new ChildResult(i);
+
+			const [key, value] = entries[i];
 			const normalizedKey = key.trim();
-			const fieldName =
-				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+			const propertyName =
+				normalizedKey === "" ? String(i) : `"${normalizedKey}"`;
 
 			if (typeof value !== "string") {
-				errors.push(`the value of field ${fieldName} should be a string`);
+				childResult.addIssue(
+					`the value of property ${propertyName} should be a string`,
+				);
 			} else if (value.trim() === "") {
-				errors.push(
-					`the value of field ${fieldName} is empty, but should be a script command`,
+				childResult.addIssue(
+					`the value of property ${propertyName} is empty, but should be a script command`,
 				);
 			}
 			if (key.trim() === "") {
-				errors.push(
-					`field ${fieldName} has an empty key, but should be a script name`,
+				childResult.addIssue(
+					`property ${propertyName} has an empty key, but should be a script name`,
 				);
 			}
-			propertyNumber++;
+			result.addChildResult(childResult);
 		}
 	} else if (obj === null) {
-		errors.push("the field is `null`, but should be an `object`");
+		result.addIssue("the value is `null`, but should be an `object`");
 	} else {
 		const valueType = Array.isArray(obj) ? "array" : typeof obj;
-		errors.push(`the type should be \`object\`, not \`${valueType}\``);
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
 	}
 
-	return errors;
+	return result;
 };

--- a/src/validators/validateType.test.ts
+++ b/src/validators/validateType.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { Result } from "../Result.ts";
 import { validateType } from "./validateType.ts";
 
 describe("validateType", () => {
 	it.each(["commonjs", "module"])(
 		"should return no issues for valid type '%s'",
 		(type) => {
-			expect(validateType(type)).toEqual(new Result());
+			expect(validateType(type).errorMessages).toEqual([]);
 		},
 	);
 

--- a/src/validators/validateVersion.test.ts
+++ b/src/validators/validateVersion.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 
-import { Result } from "../Result.ts";
 import { validateVersion } from "./validateVersion.ts";
 
 describe("validateVersion", () => {
@@ -11,7 +10,7 @@ describe("validateVersion", () => {
 		"0.0.0",
 		"1.2.3-rc.1+rev.2",
 	])("should return no issues for valid version '%s'", (version) => {
-		expect(validateVersion(version)).toEqual(new Result());
+		expect(validateVersion(version).errorMessages).toEqual([]);
 	});
 
 	it("should return an issue if the value is not a string (number)", () => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: 
    - fixes #482 
    - fixes #393
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Following the new design decided on in https://github.com/JoshuaKGoldberg/package-json-validator/issues/393, this change updates `validateScripts` to adopt the new Result return type.
