### PR TITLE
feat(validateHomepage): add function for validating `homepage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,24 @@ const packageData = {
 const result = validateFiles(packageData.files);
 ```
 
+### validateHomepage(value)
+
+This function validates the value of the `homepage` property of a `package.json`, checking that the value is a string containing a valid url.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateHomepage } from "package-json-validator";
+
+const packageData = {
+	homepage: "The Fragile",
+};
+
+const result = validateDescription(packageData.homepage);
+```
+
 ### validateLicense(value)
 
 This function validates the value of the `license` property of a `package.json`.

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -1,4 +1,4 @@
 export const emailFormat = /\S+@\S+/; // I know this isn't thorough. it's not supposed to be.
 export const packageFormat = /^[a-z0-9@/][\w@/.\-]*$/i;
-export const urlFormat = /^https*:\/\/[a-z.\-0-9]+/;
+export const urlFormat = /^https?:\/\/[a-z.\-0-9]+/;
 export const versionFormat = /^\d+\.\d[0-9+a-z.\-]+$/i;

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
 	validateDirectories,
 	validateExports,
 	validateFiles,
+	validateHomepage,
 	validateLicense,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -17,6 +17,7 @@ import {
 	validateDirectories,
 	validateExports,
 	validateFiles,
+	validateHomepage,
 	validateLicense,
 	validateScripts,
 	validateType,
@@ -67,7 +68,10 @@ const getSpecMap = (
 			engineStrict: { type: "boolean" },
 			exports: { validate: (_, value) => validateExports(value).errorMessages },
 			files: { validate: (_, value) => validateFiles(value).errorMessages },
-			homepage: { format: urlFormat, recommended: true, type: "string" },
+			homepage: {
+				recommended: true,
+				validate: (_, value) => validateHomepage(value).errorMessages,
+			},
 			keywords: { type: "array", warning: true },
 			license: { validate: (_, value) => validateLicense(value).errorMessages },
 			licenses: {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -8,6 +8,7 @@ export { validateDescription } from "./validateDescription.ts";
 export { validateDirectories } from "./validateDirectories.ts";
 export { validateExports } from "./validateExports.ts";
 export { validateFiles } from "./validateFiles.ts";
+export { validateHomepage } from "./validateHomepage.ts";
 export { validateLicense } from "./validateLicense.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validateHomepage.test.ts
+++ b/src/validators/validateHomepage.test.ts
@@ -1,16 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { validateDescription } from "./validateDescription.ts";
+import { validateHomepage } from "./validateHomepage.ts";
 
-describe("validateDescription", () => {
-	it("should return no issues for a string", () => {
-		const result = validateDescription("The Fragile");
+describe("validateHomepage", () => {
+	it("should return no issues for a valid url", () => {
+		let result = validateHomepage("https://nin.com");
+
+		expect(result.errorMessages).toEqual([]);
+
+		result = validateHomepage("http://gybe.com");
 
 		expect(result.errorMessages).toEqual([]);
 	});
 
+	it("should return an issue if the value is not a valid url", () => {
+		const result = validateHomepage("The Fragile");
+
+		expect(result.errorMessages).toEqual(["the value is not a valid url"]);
+	});
+
 	it("should return an issue if the value is not a string (number)", () => {
-		const result = validateDescription(123);
+		const result = validateHomepage(123);
 
 		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `number`",
@@ -18,7 +28,7 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if the value is not a string (object)", () => {
-		const result = validateDescription({});
+		const result = validateHomepage({});
 
 		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `object`",
@@ -26,7 +36,7 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if the value is not a string (Array)", () => {
-		const result = validateDescription([]);
+		const result = validateHomepage([]);
 
 		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `Array`",
@@ -34,7 +44,7 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if value is not a string (boolean)", () => {
-		const result = validateDescription(true);
+		const result = validateHomepage(true);
 
 		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `boolean`",
@@ -42,7 +52,7 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if value is not a string (undefined)", () => {
-		const result = validateDescription(undefined);
+		const result = validateHomepage(undefined);
 
 		expect(result.errorMessages).toEqual([
 			"the type should be a `string`, not `undefined`",
@@ -50,7 +60,7 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if value is not a string (null)", () => {
-		const result = validateDescription(null);
+		const result = validateHomepage(null);
 
 		expect(result.errorMessages).toEqual([
 			"the value is `null`, but should be a `string`",
@@ -58,18 +68,18 @@ describe("validateDescription", () => {
 	});
 
 	it("should return an issue if the value is an empty string", () => {
-		const result = validateDescription("");
+		const result = validateHomepage("");
 
 		expect(result.errorMessages).toEqual([
-			"the value is empty, but should be a description",
+			"the value is empty, but should be a valid url",
 		]);
 	});
 
 	it("should return an issue if the value is whitespace only", () => {
-		const result = validateDescription("   ");
+		const result = validateHomepage("   ");
 
 		expect(result.errorMessages).toEqual([
-			"the value is empty, but should be a description",
+			"the value is empty, but should be a valid url",
 		]);
 	});
 });

--- a/src/validators/validateHomepage.ts
+++ b/src/validators/validateHomepage.ts
@@ -1,0 +1,25 @@
+import { urlFormat } from "../formats.ts";
+import { Result } from "../Result.ts";
+
+/**
+ * Validate the `homepage` field in a package.json.
+ * It should be a string that contains a url.
+ */
+export const validateHomepage = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue("the value is empty, but should be a valid url");
+	} else if (!value.match(urlFormat)) {
+		result.addIssue("the value is not a valid url");
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #372
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateHomepage` function that validates the value of the "homepage" field of a package.json. It returns a Result object with any issues detected.

The new function is effectively the same as what the monolithic `validate` function was testing: that the value is a string that matches a url format.
