### PR TITLE
feat(validateKeywords): add function for validating `keywords`

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,28 @@ const packageData = {
 const result = validateDescription(packageData.homepage);
 ```
 
+### validateKeywords(value)
+
+This function validates the value of the `keywords` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an array
+- all items in the array should be non-empty strings
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateKeywords } from "package-json-validator";
+
+const packageData = {
+	keywords: ["eslint", "package.json"],
+};
+
+const result = validateKeywords(packageData.keywords);
+```
+
 ### validateLicense(value)
 
 This function validates the value of the `license` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
 	validateExports,
 	validateFiles,
 	validateHomepage,
+	validateKeywords,
 	validateLicense,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -18,6 +18,7 @@ import {
 	validateExports,
 	validateFiles,
 	validateHomepage,
+	validateKeywords,
 	validateLicense,
 	validateScripts,
 	validateType,
@@ -72,7 +73,10 @@ const getSpecMap = (
 				recommended: true,
 				validate: (_, value) => validateHomepage(value).errorMessages,
 			},
-			keywords: { type: "array", warning: true },
+			keywords: {
+				validate: (_, value) => validateKeywords(value).errorMessages,
+				warning: true,
+			},
 			license: { validate: (_, value) => validateLicense(value).errorMessages },
 			licenses: {
 				or: "license",

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -9,6 +9,7 @@ export { validateDirectories } from "./validateDirectories.ts";
 export { validateExports } from "./validateExports.ts";
 export { validateFiles } from "./validateFiles.ts";
 export { validateHomepage } from "./validateHomepage.ts";
+export { validateKeywords } from "./validateKeywords.ts";
 export { validateLicense } from "./validateLicense.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validateKeywords.test.ts
+++ b/src/validators/validateKeywords.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { ChildResult, Result } from "../Result.ts";
+import { validateKeywords } from "./validateKeywords.ts";
+
+describe("validateKeywords", () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateKeywords([]);
+
+		expect(result).toEqual(new Result());
+	});
+
+	it("should return no issues if the value is a valid array with all strings", () => {
+		const result = validateKeywords(["nin", "thee-silver-mt-zion"]);
+
+		expect(result).toEqual(new Result());
+	});
+
+	it("should return child results with issues if the value is an array with some non-string values", () => {
+		const result = validateKeywords(["nin", null, "thee-silver-mt-zion", 123]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.childResults).toEqual([
+			new ChildResult(0),
+			new ChildResult(1, ["item at index 1 should be a string, not `null`"]),
+			new ChildResult(2),
+			new ChildResult(3, ["item at index 3 should be a string, not `number`"]),
+		]);
+	});
+
+	it("should return child results with issues if the value is an array with non-empty strings", () => {
+		const result = validateKeywords(["", "nin", "", "thee-silver-mt-zion"]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be a keyword string",
+			"item at index 2 is empty, but should be a keyword string",
+		]);
+		expect(result.childResults).toEqual([
+			new ChildResult(0, [
+				"item at index 0 is empty, but should be a keyword string",
+			]),
+			new ChildResult(1),
+			new ChildResult(2, [
+				"item at index 2 is empty, but should be a keyword string",
+			]),
+			new ChildResult(3),
+		]);
+	});
+
+	it("should return an issue if the value is a number", () => {
+		const result = validateKeywords(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `number`",
+		]);
+		expect(result.issues[0].message).toEqual(
+			"the type should be `Array`, not `number`",
+		);
+	});
+
+	it("should return an issue if the value is an object", () => {
+		const result = validateKeywords({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `object`",
+		]);
+		expect(result.issues[0].message).toEqual(
+			"the type should be `Array`, not `object`",
+		);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateKeywords(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `Array` of strings",
+		]);
+		expect(result.issues[0].message).toEqual(
+			"the value is `null`, but should be an `Array` of strings",
+		);
+	});
+});

--- a/src/validators/validateKeywords.ts
+++ b/src/validators/validateKeywords.ts
@@ -1,0 +1,38 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * Validate the `keywords` field in a package.json, which should be an array of
+ * strings.
+ *
+ * ["eslint", "package.json"]
+ */
+export const validateKeywords = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (Array.isArray(obj)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
+			const item = obj[i];
+
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be a keyword string`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (obj == null) {
+		result.addIssue("the value is `null`, but should be an `Array` of strings");
+	} else {
+		const valueType = typeof obj;
+		result.addIssue(`the type should be \`Array\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #373
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateKeywords` function that validates the value of the "keywords" field of a package.json. It returns a Result object with any issues detected.

The new function is slightly stricter, than what the monolithic check for keywords was doing.  It was only checking that the property had an array value.  This is doing that but also checking that all items are non-empty strings.
