### PR TITLE
feat(validateMain): add function for validating `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,24 @@ const packageData = {
 const result = validateLicense(packageData.license);
 ```
 
+### validateMain(value)
+
+This function validates the value of the `main` property of a `package.json`, checking that the value is a non-empty string.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateMain } from "package-json-validator";
+
+const packageData = {
+	main: "index.js",
+};
+
+const result = validateMain(packageData.main);
+```
+
 ### validatePrivate(value)
 
 This function validates the value of the `private` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export {
 	validateHomepage,
 	validateKeywords,
 	validateLicense,
+	validateMain,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -16,6 +16,7 @@ const getPackageJson = (
 		".": "./index.js",
 	},
 	files: ["dist", "CHANGELOG.md"],
+	main: "index.js",
 	name: "test-package",
 	scripts: {
 		lint: "eslint .",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -20,6 +20,7 @@ import {
 	validateHomepage,
 	validateKeywords,
 	validateLicense,
+	validateMain,
 	validatePrivate,
 	validateScripts,
 	validateType,
@@ -85,7 +86,7 @@ const getSpecMap = (
 				validate: validateUrlTypes,
 				warning: true,
 			},
-			main: { type: "string" },
+			main: { validate: (_, value) => validateMain(value).errorMessages },
 			man: { types: ["string", "array"] },
 			name: {
 				format: packageFormat,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -11,6 +11,7 @@ export { validateFiles } from "./validateFiles.ts";
 export { validateHomepage } from "./validateHomepage.ts";
 export { validateKeywords } from "./validateKeywords.ts";
 export { validateLicense } from "./validateLicense.ts";
+export { validateMain } from "./validateMain.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validateMain.test.ts
+++ b/src/validators/validateMain.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { validateMain } from "./validateMain.ts";
+
+describe("validateMain", () => {
+	it("should return no issues for a string", () => {
+		const result = validateMain("index.js");
+
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateMain(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateMain({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (Array)", () => {
+		const result = validateMain([]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `Array`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateMain(true);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateMain(undefined);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateMain(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
+		]);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateMain("");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to the package's main module",
+		]);
+	});
+
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateMain("   ");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to the package's main module",
+		]);
+	});
+});

--- a/src/validators/validateMain.ts
+++ b/src/validators/validateMain.ts
@@ -1,0 +1,24 @@
+import { Result } from "../Result.ts";
+
+/**
+ * Validate the `main` field in a package.json.
+ * It should be a non-empty string.
+ */
+export const validateMain = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue(
+			"the value is empty, but should be the path to the package's main module",
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #374
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateMain` function that validates the value of the "main" field of a package.json. It returns a Result object with any issues detected.

The new function is slightly stricter, than what the monolithic check for keywords was doing.  It was only checking that the property had a string value.  This is doing that but also checking that it's a non-empty string.
