### PR TITLE
feat(validateMan): add function for validating `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,6 +540,28 @@ const packageData = {
 const result = validatePrivate(packageData.private);
 ```
 
+### validateMan(value)
+
+This function validates the value of the `man` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is either a string or an array of strings
+- the string(s) must end in a number (and optionally .gz)
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateMan } from "package-json-validator";
+
+const packageData = {
+	man: ["./man/foo.1", "./man/bar.1"],
+};
+
+const result = validateMan(packageData.man);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
 	validateKeywords,
 	validateLicense,
 	validateMain,
+	validateMan,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -17,6 +17,7 @@ const getPackageJson = (
 	},
 	files: ["dist", "CHANGELOG.md"],
 	main: "index.js",
+	man: ["./man/foo.1", "./man/bar.1"],
 	name: "test-package",
 	scripts: {
 		lint: "eslint .",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -21,6 +21,7 @@ import {
 	validateKeywords,
 	validateLicense,
 	validateMain,
+	validateMan,
 	validatePrivate,
 	validateScripts,
 	validateType,
@@ -87,7 +88,7 @@ const getSpecMap = (
 				warning: true,
 			},
 			main: { validate: (_, value) => validateMain(value).errorMessages },
-			man: { types: ["string", "array"] },
+			man: { validate: (_, value) => validateMan(value).errorMessages },
 			name: {
 				format: packageFormat,
 				required: !isPrivate,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -12,6 +12,7 @@ export { validateHomepage } from "./validateHomepage.ts";
 export { validateKeywords } from "./validateKeywords.ts";
 export { validateLicense } from "./validateLicense.ts";
 export { validateMain } from "./validateMain.ts";
+export { validateMan } from "./validateMan.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validateMan.test.ts
+++ b/src/validators/validateMan.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import { validateMan } from "./validateMan.ts";
+
+describe("validateMan", () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateMan([]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is an array with all valid strings", () => {
+		const result = validateMan(["./man/doc.1", "./man/doc.2.gz"]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is a valid string", () => {
+		const result = validateMan("./man/doc.1");
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return issues if the value is an array with some non-string values", () => {
+		const result = validateMan(["./man/doc.1", null, "./man/doc.2.gz", 123]);
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+		]);
+		expect(result.childResults[3].errorMessages).toEqual([
+			"item at index 3 should be a string, not `number`",
+		]);
+	});
+
+	it("should return issues if the value is an array with empty strings", () => {
+		const result = validateMan(["", "./man/doc.1", "", "./man/doc.2.gz"]);
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be the path to a man file",
+			"item at index 2 is empty, but should be the path to a man file",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"item at index 0 is empty, but should be the path to a man file",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"item at index 2 is empty, but should be the path to a man file",
+		]);
+	});
+
+	it("should return issues if the value is an array with invalid strings", () => {
+		const result = validateMan([
+			"./man/doc.one",
+			"./man/doc.gz",
+			"./man/doc.Infinity",
+			"man/doc",
+		]);
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is not valid; it should be the path to a man file",
+			"item at index 1 is not valid; it should be the path to a man file",
+			"item at index 2 is not valid; it should be the path to a man file",
+			"item at index 3 is not valid; it should be the path to a man file",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"item at index 0 is not valid; it should be the path to a man file",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"item at index 1 is not valid; it should be the path to a man file",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"item at index 2 is not valid; it should be the path to a man file",
+		]);
+		expect(result.childResults[3].errorMessages).toEqual([
+			"item at index 3 is not valid; it should be the path to a man file",
+		]);
+	});
+
+	it.each([
+		"./man/doc",
+		"man/doc",
+		"man/doc.one",
+		"./man/doc.",
+		"man/doc.Infinity",
+		"./man/doc.gz",
+	])(
+		"should return an issue if the value is an invalid string (%s)",
+		(input) => {
+			const result = validateMan(input);
+			expect(result.errorMessages).toEqual([
+				"the value is not valid; it should be the path to a man file",
+			]);
+			expect(result.issues).toHaveLength(1);
+		},
+	);
+
+	it("should return an issue if the value is an empty string", () => {
+		let result = validateMan("");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to a man file",
+		]);
+		expect(result.issues).toHaveLength(1);
+
+		result = validateMan("     ");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to a man file",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return issues if the value is a number", () => {
+		const result = validateMan(123);
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array` or `string`, not `number`",
+		]);
+	});
+
+	it("should return issues if the value is an object", () => {
+		const result = validateMan({});
+		expect(result.issues).toEqual([
+			{ message: "the type should be `Array` or `string`, not `object`" },
+		]);
+	});
+
+	it("should return issues if the value is null", () => {
+		const result = validateMan(null);
+		expect(result.issues).toEqual([
+			{
+				message: "the value is `null`, but should be an `Array` or a `string`",
+			},
+		]);
+	});
+});

--- a/src/validators/validateMan.ts
+++ b/src/validators/validateMan.ts
@@ -1,0 +1,68 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * The string should end in a number and optionally .gz
+ */
+const isManStringValid = (man: string): boolean => {
+	const stringParts = man.split(".");
+	let fileEnd = stringParts.at(-1);
+	if (fileEnd === "gz") {
+		fileEnd = stringParts.at(-2);
+	}
+	return !!fileEnd && !isNaN(parseInt(fileEnd));
+};
+
+/**
+ * Validate the `man` field in a package.json, which can either be
+ * a string or an array of strings.
+ * The string(s) must end with a number (and optionally .gz)
+ * @example ["./man/foo.1", "./man/bar.1"]
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#man
+ */
+export const validateMan = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (typeof obj === "string") {
+		if (obj.trim() === "") {
+			result.addIssue(
+				"the value is empty, but should be the path to a man file",
+			);
+		} else if (!isManStringValid(obj)) {
+			result.addIssue(
+				"the value is not valid; it should be the path to a man file",
+			);
+		}
+	} else if (Array.isArray(obj)) {
+		// If it's an array, check if all items are valid strings
+		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
+			const item = obj[i];
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be the path to a man file`,
+				);
+			} else if (!isManStringValid(item)) {
+				childResult.addIssue(
+					`item at index ${i} is not valid; it should be the path to a man file`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (obj == null) {
+		result.addIssue(
+			"the value is `null`, but should be an `Array` or a `string`",
+		);
+	} else {
+		const valueType = typeof obj;
+		result.addIssue(
+			`the type should be \`Array\` or \`string\`, not \`${valueType}\``,
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #375
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateMan` function that validates the value of the "man" field of a package.json. It returns a Result object with any issues detected.

The new function is stricter than the existing `validate` function.  It only checked that the value was a string or array.  This function checks that but also validates that the string(s) end in a number (and optionally .gz).
