### PR TITLE
feat(validatePrivate): add function for validating `private`

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,25 @@ const packageData = {
 const result = validateLicense(packageData.license);
 ```
 
+### validatePrivate(value)
+
+This function validates the value of the `private` property of a `package.json`.
+It takes the value, and checks that it's a boolean.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validatePrivate } from "package-json-validator";
+
+const packageData = {
+	private: true,
+};
+
+const result = validatePrivate(packageData.private);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
 	validateLicense,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,
+	validatePrivate,
 	validateScripts,
 	validateType,
 	validateVersion,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -19,6 +19,7 @@ import {
 	validateFiles,
 	validateHomepage,
 	validateLicense,
+	validatePrivate,
 	validateScripts,
 	validateType,
 	validateUrlOrMailto,
@@ -95,7 +96,7 @@ const getSpecMap = (
 				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			preferGlobal: { type: "boolean" },
-			private: { type: "boolean" },
+			private: { validate: (_, value) => validatePrivate(value).errorMessages },
 			publishConfig: { type: "object" },
 			repository: {
 				or: "repositories",

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -10,6 +10,7 @@ export { validateExports } from "./validateExports.ts";
 export { validateFiles } from "./validateFiles.ts";
 export { validateHomepage } from "./validateHomepage.ts";
 export { validateLicense } from "./validateLicense.ts";
+export { validatePrivate } from "./validatePrivate.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.ts";

--- a/src/validators/validatePrivate.test.ts
+++ b/src/validators/validatePrivate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePrivate } from "./validatePrivate.ts";
+
+describe("validatePrivate", () => {
+	it.each([true, false])(
+		"should return no issues for boolean values '%s'",
+		(type) => {
+			const result = validatePrivate(type);
+			expect(result.errorMessages).toEqual([]);
+		},
+	);
+
+	it("should return an issue if type is not a boolean (number)", () => {
+		const result = validatePrivate(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `number`",
+		]);
+	});
+
+	it("should return error if type is not a boolean (object)", () => {
+		const result = validatePrivate({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `object`",
+		]);
+	});
+
+	it("should return error if type is not a boolean (array)", () => {
+		const result = validatePrivate([]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `array`",
+		]);
+	});
+
+	it("should return error if type is not a boolean (string)", () => {
+		const result = validatePrivate("the fragile");
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `string`",
+		]);
+	});
+
+	it("should return error if type is a boolean string", () => {
+		const result = validatePrivate("true");
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `string`",
+		]);
+	});
+
+	it("should return error if type is not a boolean (undefined)", () => {
+		const result = validatePrivate(undefined);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `boolean`, not `undefined`",
+		]);
+	});
+
+	it("should return error if type is not a boolean (null)", () => {
+		const result = validatePrivate(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `boolean`",
+		]);
+	});
+});

--- a/src/validators/validatePrivate.ts
+++ b/src/validators/validatePrivate.ts
@@ -1,0 +1,19 @@
+import { Result } from "../Result.ts";
+
+/**
+ * Validate the `private` field in a package.json, which should be a boolean value
+ */
+export const validatePrivate = (type: unknown): Result => {
+	const result = new Result();
+
+	if (typeof type !== "boolean") {
+		if (type === null) {
+			result.addIssue("the value is `null`, but should be a `boolean`");
+		} else {
+			const valueType = Array.isArray(type) ? "array" : typeof type;
+			result.addIssue(`the type should be a \`boolean\`, not \`${valueType}\``);
+		}
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #377
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validatePrivate` function that validates the value of the "private" field of a package.json. It returns a Result object with any issues detected.

The new function simply checks that the value is a boolean, which is equivalent to what the monolithic `validate` function was doing.
