### PR TITLE
feat(validateCpu): add validation for specific arch types

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,12 @@ This function validates the value of the `cpu` property of a `package.json`.
 It takes the value, and validates it against the following criteria.
 
 - the property is an array
-- all items in the array should be non-empty strings
+- all items in the array should be one of the following:
+
+"arm", "arm64", "ia32", "loong64", "mips", "mipsel", "ppc64", "riscv64", "s390", "s390x", "x64"
+
+> [!NOTE]
+> These values are the list of possible `process.arch` values [documented by Node](https://nodejs.org/api/process.html#processarch).
 
 It returns a `Result` object (See [Result Types](#result-types)).
 

--- a/src/validators/validateCpu.test.ts
+++ b/src/validators/validateCpu.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it } from "vitest";
 
 import { validateCpu } from "./validateCpu.ts";
 
+const VALID_ARCHS = [
+	"arm",
+	"arm64",
+	"ia32",
+	"loong64",
+	"mips",
+	"mipsel",
+	"ppc64",
+	"riscv64",
+	"s390",
+	"s390x",
+	"x64",
+];
+
 describe("validateCpu", () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateCpu([]);
@@ -9,14 +23,27 @@ describe("validateCpu", () => {
 		expect(result.errorMessages).toEqual([]);
 	});
 
-	it("should return no issues if the value is a valid array with all strings", () => {
-		const result = validateCpu(["nin", "thee-silver-mt-zion"]);
+	it("should return no issues if the value is an array with valid string values", () => {
+		const result = validateCpu(VALID_ARCHS);
 
 		expect(result.errorMessages).toEqual([]);
 	});
 
+	it("should return issues if the value is an array with invalid strings", () => {
+		const result = validateCpu(["android", "y128"]);
+
+		expect(result.errorMessages).toEqual([
+			`the value "android" is not valid. Valid CPU values are: ${VALID_ARCHS.join(", ")}`,
+			`the value "y128" is not valid. Valid CPU values are: ${VALID_ARCHS.join(", ")}`,
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
+	});
+
 	it("should return child results with issues if the value is an array with some non-string values", () => {
-		const result = validateCpu(["nin", null, "thee-silver-mt-zion", 123]);
+		const result = validateCpu(["arm", null, "x64", 123]);
 
 		expect(result.errorMessages).toEqual([
 			"item at index 1 should be a string, not `null`",
@@ -31,7 +58,7 @@ describe("validateCpu", () => {
 	});
 
 	it("should return child results with issues if the value is an array with non-empty strings", () => {
-		const result = validateCpu(["", "nin", "", "thee-silver-mt-zion"]);
+		const result = validateCpu(["", "arm", "", "x64"]);
 
 		expect(result.errorMessages).toEqual([
 			"item at index 0 is empty, but should be the name of a CPU architecture",

--- a/src/validators/validateCpu.ts
+++ b/src/validators/validateCpu.ts
@@ -1,5 +1,19 @@
 import { ChildResult, Result } from "../Result.ts";
 
+const VALID_ARCHS = [
+	"arm",
+	"arm64",
+	"ia32",
+	"loong64",
+	"mips",
+	"mipsel",
+	"ppc64",
+	"riscv64",
+	"s390",
+	"s390x",
+	"x64",
+];
+
 /**
  * Validate the `cpu` field in a package.json, which should be an array of
  * strings.
@@ -23,6 +37,10 @@ export const validateCpu = (obj: unknown): Result => {
 			} else if (item.trim() === "") {
 				childResult.addIssue(
 					`item at index ${i} is empty, but should be the name of a CPU architecture`,
+				);
+			} else if (!VALID_ARCHS.includes(item)) {
+				childResult.addIssue(
+					`the value "${item}" is not valid. Valid CPU values are: ${VALID_ARCHS.join(", ")}`,
 				);
 			}
 			result.addChildResult(childResult);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #540
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change strengthens the validate for the `cpu` field, checking it again the list of documented `process.arch` values.
