### PR TITLE
feat(validateOs): add function for validating `os`

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,33 @@ const packageData = {
 const result = validateName(packageData.name);
 ```
 
+### validateOs(value)
+
+This function validates the value of the `os` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an array
+- all items in the array should be one of the following:
+
+"aix", "android", "darwin", "freebsd", "linux", "openbsd", "sunos", and "win32"
+
+> [!NOTE]
+> These values are the list of possible `process.platform` values [documented by Node](https://nodejs.org/api/process.html#processplatform).
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateOs } from "package-json-validator";
+
+const packageData = {
+	os: ["linux", "win32"],
+};
+
+const result = validateOs(packageData.os);
+```
+
 ### validatePrivate(value)
 
 This function validates the value of the `private` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 	validateMan,
 	validateName,
 	validateDependencies as validateOptionalDependencies,
+	validateOs,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,
 	validateRepository,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -19,6 +19,7 @@ const getPackageJson = (
 	main: "index.js",
 	man: ["./man/foo.1", "./man/bar.1"],
 	name: "test-package",
+	os: ["win32"],
 	scripts: {
 		lint: "eslint .",
 	},

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -24,6 +24,7 @@ import {
 	validateMain,
 	validateMan,
 	validateName,
+	validateOs,
 	validatePrivate,
 	validateRepository,
 	validateScripts,
@@ -99,7 +100,7 @@ const getSpecMap = (
 			optionalDependencies: {
 				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
-			os: { type: "array" },
+			os: { validate: (_, value) => validateOs(value).errorMessages },
 			peerDependencies: {
 				validate: (_, value) => validateDependencies(value).errorMessages,
 			},

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -15,6 +15,7 @@ export { validateLicense } from "./validateLicense.ts";
 export { validateMain } from "./validateMain.ts";
 export { validateMan } from "./validateMan.ts";
 export { validateName } from "./validateName.ts";
+export { validateOs } from "./validateOs.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validateRepository } from "./validateRepository.ts";
 export { validateScripts } from "./validateScripts.ts";

--- a/src/validators/validateOs.test.ts
+++ b/src/validators/validateOs.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { validateOs } from "./validateOs.ts";
+
+const VALID_OSS = [
+	"aix",
+	"android",
+	"darwin",
+	"freebsd",
+	"linux",
+	"openbsd",
+	"sunos",
+	"win32",
+];
+
+describe("validateOs", () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateOs([]);
+
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is an array with valid string values", () => {
+		const result = validateOs(VALID_OSS);
+
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return issues if the value is an array with invalid strings", () => {
+		const result = validateOs(["arm", "x64"]);
+
+		expect(result.errorMessages).toEqual([
+			`the value "arm" is not valid. Valid OS values are: ${VALID_OSS.join(", ")}`,
+			`the value "x64" is not valid. Valid OS values are: ${VALID_OSS.join(", ")}`,
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toHaveLength(1);
+	});
+
+	it("should return child results with issues if the value is an array with some non-string values", () => {
+		const result = validateOs(["win32", null, "linux", 123]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].issues).toEqual([]);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[2].issues).toEqual([]);
+		expect(result.childResults[3].issues).toHaveLength(1);
+	});
+
+	it("should return child results with issues if the value is an array with non-empty strings", () => {
+		const result = validateOs(["", "win32", "", "linux"]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be the name of an operating system",
+			"item at index 2 is empty, but should be the name of an operating system",
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toEqual([]);
+		expect(result.childResults[2].issues).toHaveLength(1);
+		expect(result.childResults[3].issues).toEqual([]);
+	});
+
+	it("should return an issue if the value is a number", () => {
+		const result = validateOs(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is an object", () => {
+		const result = validateOs({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `object`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateOs(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `Array` of strings",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+});

--- a/src/validators/validateOs.ts
+++ b/src/validators/validateOs.ts
@@ -1,0 +1,53 @@
+import { ChildResult, Result } from "../Result.ts";
+
+const VALID_OSS = [
+	"aix",
+	"android",
+	"darwin",
+	"freebsd",
+	"linux",
+	"openbsd",
+	"sunos",
+	"win32",
+];
+
+/**
+ * Validate the `os` field in a package.json, which should be an array of
+ * valid operating systems.
+ * @example ["linux", "win32"]
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#os
+ */
+export const validateOs = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (Array.isArray(obj)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
+			const item = obj[i];
+
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be the name of an operating system`,
+				);
+			} else if (!VALID_OSS.includes(item)) {
+				childResult.addIssue(
+					`the value "${item}" is not valid. Valid OS values are: ${VALID_OSS.join(", ")}`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (obj == null) {
+		result.addIssue("the value is `null`, but should be an `Array` of strings");
+	} else {
+		const valueType = typeof obj;
+		result.addIssue(`the type should be \`Array\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #376
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateOs` function that validates the value of the "os" field of a package.json. It returns a Result object with any issues detected.

The new function is stricter than the existing `validate` function.  It only checked that the value an array.  This function checks that but also validates that the items in the array are all strings from the list of possible node platforms.
