### PR TITLE
feat(validatePublishConfig): add function for validating `publishConfig`

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,45 @@ const packageData = {
 const result = validatePrivate(packageData.private);
 ```
 
+### validatePublishConfig(value)
+
+This function validates the value of the `publishConfig` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an object
+- if any of the following properties are present, they should conform to the type defined by the package manager
+  - access
+  - bin
+  - cpu
+  - directory
+  - exports
+  - main
+  - provenance
+  - tag
+
+> [!NOTE]
+> These properties are a (non-exhaustive) combination of those supported by `npm`, `pnpm`, and `yarn`.
+>
+> - <https://docs.npmjs.com/cli/v11/commands/npm-publish#configuration>
+> - <https://pnpm.io/package_json#publishconfig>
+> - <https://yarnpkg.com/configuration/manifest#publishConfig>
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validatePublishConfig } from "package-json-validator";
+
+const packageData = {
+	publishConfig: {
+		provenance: true,
+	},
+};
+
+const result = validatePublishConfig(packageData.publishConfig);
+```
+
 ### validateRepository(value)
 
 This function validates the value of the `repository` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
 	validateOs,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,
+	validatePublishConfig,
 	validateRepository,
 	validateScripts,
 	validateType,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -20,6 +20,10 @@ const getPackageJson = (
 	man: ["./man/foo.1", "./man/bar.1"],
 	name: "test-package",
 	os: ["win32"],
+	publishConfig: {
+		access: "public",
+		provenance: true,
+	},
 	scripts: {
 		lint: "eslint .",
 	},

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -26,6 +26,7 @@ import {
 	validateName,
 	validateOs,
 	validatePrivate,
+	validatePublishConfig,
 	validateRepository,
 	validateScripts,
 	validateType,
@@ -105,7 +106,9 @@ const getSpecMap = (
 				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
 			private: { validate: (_, value) => validatePrivate(value).errorMessages },
-			publishConfig: { type: "object" },
+			publishConfig: {
+				validate: (_, value) => validatePublishConfig(value).errorMessages,
+			},
 			repository: {
 				validate: (_, value) => validateRepository(value).errorMessages,
 				warning: true,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -17,6 +17,7 @@ export { validateMan } from "./validateMan.ts";
 export { validateName } from "./validateName.ts";
 export { validateOs } from "./validateOs.ts";
 export { validatePrivate } from "./validatePrivate.ts";
+export { validatePublishConfig } from "./validatePublishConfig.ts";
 export { validateRepository } from "./validateRepository.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validatePublishConfig.test.ts
+++ b/src/validators/validatePublishConfig.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePublishConfig } from "./validatePublishConfig.ts";
+
+describe("validatePublishConfig", () => {
+	it("should return no issues if the value is an empty object", () => {
+		const result = validatePublishConfig({});
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is an object with no known properties", () => {
+		const result = validatePublishConfig({
+			debug: true,
+			host: "localhost",
+			port: 8080,
+		});
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(3);
+	});
+
+	it.each([
+		{
+			access: "restricted",
+			bin: "./bin/cli.js",
+			cpu: ["arm64", "x64"],
+			directory: "dist",
+			exports: {
+				".": "./dist/index.js",
+				"./secondary": "./dist/secondary.js",
+			},
+			main: "./dist/index.js",
+			provenance: true,
+			tag: "dev",
+		},
+		{
+			access: null,
+			cpu: [],
+			exports: "./dist/index.js",
+		},
+	])(
+		"should return no issues if the value is an object with known properties (%0)",
+		(input) => {
+			const result = validatePublishConfig(input);
+			expect(result.errorMessages).toEqual([]);
+		},
+	);
+
+	it.each([
+		[
+			{
+				access: "not right",
+				bin: "",
+				cpu: ["", "   "],
+				directory: "",
+				exports: {
+					"": "./dist/index.js",
+					"./secondary": "",
+				},
+				main: "",
+				provenance: null,
+				tag: "",
+			},
+			[
+				'the value "not right" is not valid. Valid types are: public, restricted',
+				"the value is empty, but should be a relative path",
+				"item at index 0 is empty, but should be the name of a CPU architecture",
+				"item at index 1 is empty, but should be the name of a CPU architecture",
+				"the value is empty, but should be the path to a subdirectory",
+				"property 0 has an empty key, but should be an export condition",
+				'the value of "./secondary" is empty, but should be an entry point path',
+				"the value is empty, but should be the path to the package's main module",
+				"the value is `null`, but should be a `boolean`",
+				"the value is empty, but should be a release tag",
+			],
+		],
+		[
+			{
+				access: "",
+				bin: 123,
+				cpu: 123,
+				directory: 123,
+				exports: {
+					"": 123,
+					"./secondary": null,
+				},
+				main: 123,
+				provenance: 123,
+				tag: 123,
+			},
+			[
+				'the value is empty, but should be "public" or "restricted"',
+				"the type should be `string` or `object`, not `number`",
+				"the type should be `Array`, not `number`",
+				"the type should be a `string`, not `number`",
+				"the value of property 0 should be either an entry point path or an object of export conditions",
+				"property 0 has an empty key, but should be an export condition",
+				'the value of "./secondary" should be either an entry point path or an object of export conditions',
+				"the type should be a `string`, not `number`",
+				"the type should be a `boolean`, not `number`",
+				"the type should be a `string`, not `number`",
+			],
+		],
+		[
+			{
+				access: "",
+				bin: 123,
+				cpu: 123,
+				directory: 123,
+				exports: {
+					"": 123,
+					"./secondary": null,
+				},
+				main: 123,
+				provenance: 123,
+				tag: 123,
+			},
+			[
+				'the value is empty, but should be "public" or "restricted"',
+				"the type should be `string` or `object`, not `number`",
+				"the type should be `Array`, not `number`",
+				"the type should be a `string`, not `number`",
+				"the value of property 0 should be either an entry point path or an object of export conditions",
+				"property 0 has an empty key, but should be an export condition",
+				'the value of "./secondary" should be either an entry point path or an object of export conditions',
+				"the type should be a `string`, not `number`",
+				"the type should be a `boolean`, not `number`",
+				"the type should be a `string`, not `number`",
+			],
+		],
+		[
+			{
+				access: undefined,
+				bin: null,
+				cpu: undefined,
+				directory: null,
+				exports: 123,
+				main: undefined,
+				provenance: undefined,
+				tag: undefined,
+			},
+			[
+				"the type should be a `string`, not `undefined`",
+				"the value is `null`, but should be a `string` or an `object`",
+				"the value is `null`, but should be an `Array` of strings",
+				"the value is `null`, but should be a `string`",
+				"the type should be `object` or `string`, not `number`",
+				"the type should be a `string`, not `undefined`",
+				"the type should be a `boolean`, not `undefined`",
+				"the type should be a `string`, not `undefined`",
+			],
+		],
+		[
+			{
+				access: [],
+				directory: [],
+				provenance: [],
+				tag: [],
+			},
+			[
+				"the type should be a `string`, not `Array`",
+				"the type should be a `string`, not `Array`",
+				"the type should be a `boolean`, not `Array`",
+				"the type should be a `string`, not `Array`",
+			],
+		],
+	])(
+		"should return issues if known properties don't pass validation ($1)",
+		(input, expected) => {
+			const result = validatePublishConfig(input);
+			expect(result.errorMessages).toEqual(expected);
+		},
+	);
+
+	it("should return issues if the value is an array", () => {
+		const result = validatePublishConfig(["array", "of", "values"]);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `Array`",
+		]);
+	});
+
+	it("should return issues if the value is null", () => {
+		const result = validatePublishConfig(null);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
+	});
+
+	it("should return issues if the value is a string", () => {
+		const result = validatePublishConfig("string");
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `string`",
+		]);
+	});
+});

--- a/src/validators/validatePublishConfig.ts
+++ b/src/validators/validatePublishConfig.ts
@@ -1,0 +1,107 @@
+import { Result } from "../Result.ts";
+import { validateBin } from "./validateBin.ts";
+import { validateCpu } from "./validateCpu.ts";
+import { validateExports } from "./validateExports.ts";
+import { validateMain } from "./validateMain.ts";
+
+const VALID_ACCESS = ["public", "restricted"];
+
+const validateAccess = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value !== null) {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue(
+			`the value is empty, but should be "public" or "restricted"`,
+		);
+	} else if (!VALID_ACCESS.includes(value)) {
+		result.addIssue(
+			`the value "${value}" is not valid. Valid types are: ${VALID_ACCESS.join(", ")}`,
+		);
+	}
+	return result;
+};
+
+const validateBoolean = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "boolean") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `boolean`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`boolean\`, not \`${valueType}\``);
+		}
+	}
+
+	return result;
+};
+
+const validateString = (
+	value: unknown,
+	propertyDescription: string,
+): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue(`the value is empty, but should be ${propertyDescription}`);
+	}
+	return result;
+};
+
+const propertyValidators: Record<string, (value: unknown) => Result> = {
+	access: validateAccess,
+	bin: validateBin,
+	cpu: validateCpu,
+	directory: (value) => validateString(value, "the path to a subdirectory"),
+	exports: validateExports,
+	main: validateMain,
+	provenance: validateBoolean,
+	tag: (value) => validateString(value, "a release tag"),
+};
+
+/**
+ * Validate the `publishConfig` field in a package.json. The value
+ * should be an object.  And when present, specific properties should conform
+ * to the types that their respective package manager supports
+ * @see https://docs.npmjs.com/cli/v11/commands/npm-publish#configuration
+ * @see https://pnpm.io/package_json#publishconfig
+ * @see https://yarnpkg.com/configuration/manifest#publishConfig
+ */
+export const validatePublishConfig = (value: unknown): Result => {
+	const result = new Result();
+
+	if (value === null) {
+		result.addIssue("the value is `null`, but should be an `object`");
+	} else if (typeof value !== "object" || Array.isArray(value)) {
+		const valueType = Array.isArray(value) ? "Array" : typeof value;
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
+	} else {
+		// Validate specific properties
+		const entries = Object.entries(value);
+		for (let i = 0; i < entries.length; i++) {
+			const [key, value] = entries[i];
+			let childResult: Result;
+			if (key in propertyValidators) {
+				childResult = propertyValidators[key](value);
+			} else {
+				childResult = new Result();
+			}
+
+			result.addChildResult(i, childResult);
+		}
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #378
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validatePublishConfig` function that validates the value of the "publishConfig" field of a package.json. It returns a Result object with any issues detected.

The new function is much stricter than what the monolith `validate` function was checking.  It was only checking if the value was an object.  Now we're doing that, but also checking the values of specific properties (when present) that are known to be supported by npm, pnpm, and yarn.  I didn't include every single property that these package managers support, but picked the ones that seemed like they'd be used the most.  If we need to add more, it's fairly easy to do.
