### PR TITLE
feat(validateWorkspaces): add function for validating `workspaces`

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,28 @@ const packageData = {
 const result = validateVersion(packageData.version);
 ```
 
+### validateWorkspaces(value)
+
+This function validates the value of the `workspaces` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an array
+- all items in the array should be non-empty strings
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateWorkspaces } from "package-json-validator";
+
+const packageData = {
+	workspaces: ["./app", "./packages/*"],
+};
+
+const result = validateWorkspaces(packageData.cpu);
+```
+
 ## Specification
 
 This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,4 +24,5 @@ export {
 	validateScripts,
 	validateType,
 	validateVersion,
+	validateWorkspaces,
 } from "./validators/index.ts";

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -24,6 +24,7 @@ const getPackageJson = (
 	},
 	type: "module",
 	version: "0.5.0",
+	workspaces: ["./packages/*"],
 	...extra,
 });
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -27,6 +27,7 @@ import {
 	validateType,
 	validateUrlOrMailto,
 	validateVersion,
+	validateWorkspaces,
 } from "./validators/index.js";
 
 const getSpecMap = (
@@ -118,6 +119,9 @@ const getSpecMap = (
 			version: {
 				required: !isPrivate,
 				validate: (_, value) => validateVersion(value).errorMessages,
+			},
+			workspaces: {
+				validate: (_, value) => validateWorkspaces(value).errorMessages,
 			},
 		};
 	} else if (specName == "commonjs_1.0") {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -18,3 +18,4 @@ export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.ts";
 export { validateVersion } from "./validateVersion.ts";
+export { validateWorkspaces } from "./validateWorkspaces.ts";

--- a/src/validators/validateWorkspaces.test.ts
+++ b/src/validators/validateWorkspaces.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { validateWorkspaces } from "./validateWorkspaces.ts";
+
+describe("validateWorkspaces", () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateWorkspaces([]);
+
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is a valid array with all strings", () => {
+		const result = validateWorkspaces([
+			"app",
+			"./packages/a",
+			"./packages/b",
+			"./tools/*",
+		]);
+
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(4);
+	});
+
+	it("should return issues if the value is an array with some non-string values", () => {
+		const result = validateWorkspaces([
+			"app",
+			null,
+			"./packages/*",
+			123,
+			undefined,
+			[],
+		]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+			"item at index 4 should be a string, not `undefined`",
+			"item at index 5 should be a string, not `Array`",
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(6);
+		expect(result.childResults[0].issues).toEqual([]);
+		expect(result.childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[2].issues).toEqual([]);
+		expect(result.childResults[3].issues).toHaveLength(1);
+		expect(result.childResults[4].issues).toHaveLength(1);
+		expect(result.childResults[5].issues).toHaveLength(1);
+	});
+
+	it("should return issues if the value is an array with non-empty strings", () => {
+		const result = validateWorkspaces(["", "app", "", "./packages/*"]);
+
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be a file path or glob pattern",
+			"item at index 2 is empty, but should be a file path or glob pattern",
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].issues).toEqual([]);
+		expect(result.childResults[2].issues).toHaveLength(1);
+		expect(result.childResults[3].issues).toEqual([]);
+	});
+
+	it("should return an issue if the value is a number", () => {
+		const result = validateWorkspaces(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is an object", () => {
+		const result = validateWorkspaces({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array`, not `object`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateWorkspaces(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `Array` of strings",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+});

--- a/src/validators/validateWorkspaces.ts
+++ b/src/validators/validateWorkspaces.ts
@@ -1,0 +1,40 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * Validate the `workspaces` field in a package.json, which should be an array of
+ * file patterns.
+ *
+ * ["./app", "./packages/*"]
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#workspaces
+ */
+export const validateWorkspaces = (value: unknown): Result => {
+	const result = new Result();
+
+	if (Array.isArray(value)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < value.length; i++) {
+			const childResult = new ChildResult(i);
+			const item = value[i];
+
+			if (typeof item !== "string") {
+				const itemType =
+					item === null ? "null" : Array.isArray(item) ? "Array" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be a file path or glob pattern`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (value == null) {
+		result.addIssue("the value is `null`, but should be an `Array` of strings");
+	} else {
+		const valueType = typeof value;
+		result.addIssue(`the type should be \`Array\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #380
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateWorkspaces` function that validates the value of the "workspaces" field of a package.json. It returns a Result object with any issues detected.

The monolithic `validate` function wasn't checking this property at all, and so this will be net new validation for it.
