### PR TITLE
feat(validateEngines): add function for validating `engines`

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,30 @@ const packageData = {
 const result = validateDirectories(packageData.directories);
 ```
 
+### validateEngines(value)
+
+This function validates the value of the `engines` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- It should be of type `object`.
+- It should be a key to string value object, and the values should all be non-empty.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateEngines } from "package-json-validator";
+
+const packageData = {
+	engines: {
+		node: "^20.19.0 || >=22.12.0",
+	},
+};
+
+const result = validateEngines(packageData.engines);
+```
+
 ### validateExports(value)
 
 This function validates the value of the `exports` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
 	validateDescription,
 	validateDependencies as validateDevDependencies,
 	validateDirectories,
+	validateEngines,
 	validateExports,
 	validateFiles,
 	validateHomepage,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -15,6 +15,7 @@ import {
 	validateDependencies,
 	validateDescription,
 	validateDirectories,
+	validateEngines,
 	validateExports,
 	validateFiles,
 	validateHomepage,
@@ -68,7 +69,10 @@ const getSpecMap = (
 			directories: {
 				validate: (_, value) => validateDirectories(value).errorMessages,
 			},
-			engines: { recommended: true, type: "object" },
+			engines: {
+				recommended: true,
+				validate: (_, value) => validateEngines(value).errorMessages,
+			},
 			engineStrict: { type: "boolean" },
 			exports: { validate: (_, value) => validateExports(value).errorMessages },
 			files: { validate: (_, value) => validateFiles(value).errorMessages },

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -6,6 +6,7 @@ export { validateCpu } from "./validateCpu.ts";
 export { validateDependencies } from "./validateDependencies.ts";
 export { validateDescription } from "./validateDescription.ts";
 export { validateDirectories } from "./validateDirectories.ts";
+export { validateEngines } from "./validateEngines.ts";
 export { validateExports } from "./validateExports.ts";
 export { validateFiles } from "./validateFiles.ts";
 export { validateHomepage } from "./validateHomepage.ts";

--- a/src/validators/validateEngines.test.ts
+++ b/src/validators/validateEngines.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import { validateEngines } from "./validateEngines.ts";
+
+describe(validateEngines, () => {
+	it("should return no issues if the value is an empty object", () => {
+		const result = validateEngines({});
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return issues if the value is an object with all keys having valid string values", () => {
+		const result = validateEngines({
+			node: "^24.11.0",
+			npm: "Please use pnpm",
+			pnpm: "^10",
+		});
+		expect(result.errorMessages).toEqual([]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		result.childResults.forEach((childResult) => {
+			expect(childResult.issues).toHaveLength(0);
+		});
+	});
+
+	it("should return issues if the value is an object with some keys having invalid paths", () => {
+		const result = validateEngines({
+			node: "^24.11.0",
+			npm: "      ",
+			pnpm: "",
+		});
+		expect(result.errorMessages).toEqual([
+			'the value of property "npm" is empty, but should be a semver range',
+			'the value of property "pnpm" is empty, but should be a semver range',
+		]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "npm" is empty, but should be a semver range',
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			'the value of property "pnpm" is empty, but should be a semver range',
+		]);
+	});
+
+	it("should return issues if the value is an object with an empty string key", () => {
+		const result = validateEngines({
+			"": "^24.11.0",
+			"  ": "^10",
+			"    ": "",
+		});
+		expect(result.errorMessages).toHaveLength(4);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"property 0 has an empty key, but should be a runtime or package manager",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"property 1 has an empty key, but should be a runtime or package manager",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"the value of property 2 is empty, but should be a semver range",
+			"property 2 has an empty key, but should be a runtime or package manager",
+		]);
+	});
+
+	it("should return issues if the value is an object with some keys having non-string values", () => {
+		const result = validateEngines({
+			node: "^24.11.0",
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			npm: 123 as any,
+		});
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "npm" should be a string',
+		]);
+	});
+
+	it("should return an issue if the value is neither a string nor an object", () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result = validateEngines(123 as any);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the value is an array", () => {
+		const result = validateEngines(["node"]);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `Array`",
+		]);
+	});
+
+	it("should return an issue if the value is a string", () => {
+		const result = validateEngines("node");
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `string`",
+		]);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateEngines(null);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object`",
+		]);
+	});
+
+	it("should return an issue if the value is undefined", () => {
+		const result = validateEngines(undefined);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `undefined`",
+		]);
+	});
+});

--- a/src/validators/validateEngines.ts
+++ b/src/validators/validateEngines.ts
@@ -1,0 +1,49 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * Validate the `engines` field in a package.json, which should be a
+ * Record&lt;string, string&gt; where the key is the name of a runtime or
+ * package manager, and the value is the supported semver range.
+ *
+ * {
+ *   "node": "^20.19.0 || >=22.12.0"
+ * },
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#engines
+ */
+export const validateEngines = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+		let propertyNumber = 0;
+		for (const [key, value] of Object.entries(obj)) {
+			const childResult = new ChildResult(propertyNumber);
+			const normalizedKey = key.trim();
+			const fieldName =
+				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+
+			if (typeof value !== "string") {
+				childResult.addIssue(
+					`the value of property ${fieldName} should be a string`,
+				);
+			} else if (value.trim() === "") {
+				childResult.addIssue(
+					`the value of property ${fieldName} is empty, but should be a semver range`,
+				);
+			}
+			if (key.trim() === "") {
+				childResult.addIssue(
+					`property ${fieldName} has an empty key, but should be a runtime or package manager`,
+				);
+			}
+			result.addChildResult(childResult);
+			propertyNumber++;
+		}
+	} else if (obj === null) {
+		result.addIssue("the value is `null`, but should be an `object`");
+	} else {
+		const valueType = Array.isArray(obj) ? "Array" : typeof obj;
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #535
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateEngines` function that validates the value of the "engines" field of a package.json. It returns a Result object with any issues detected.

The new function is a bit stricter than what the monolith `validate` function was checking.  It was only checking if the value was an object.  Now we're doing that, but also checking that the values and keys are all non-empty strings.
