### PR TITLE
feat(validateName): add function for validating `name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,25 +545,6 @@ const packageData = {
 const result = validateMain(packageData.main);
 ```
 
-### validatePrivate(value)
-
-This function validates the value of the `private` property of a `package.json`.
-It takes the value, and checks that it's a boolean.
-
-It returns a `Result` object (See [Result Types](#result-types)).
-
-#### Examples
-
-```ts
-import { validatePrivate } from "package-json-validator";
-
-const packageData = {
-	private: true,
-};
-
-const result = validatePrivate(packageData.private);
-```
-
 ### validateMan(value)
 
 This function validates the value of the `man` property of a `package.json`.
@@ -584,6 +565,44 @@ const packageData = {
 };
 
 const result = validateMan(packageData.man);
+```
+
+### validateName(value)
+
+This function validates the value of the `name` property of a `package.json`.
+It takes the value, and validates it using `validate-npm-package-name`, which is the same package that npm uses.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateName } from "package-json-validator";
+
+const packageData = {
+	name: "some-package",
+};
+
+const result = validateName(packageData.name);
+```
+
+### validatePrivate(value)
+
+This function validates the value of the `private` property of a `package.json`.
+It takes the value, and checks that it's a boolean.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validatePrivate } from "package-json-validator";
+
+const packageData = {
+	private: true,
+};
+
+const result = validatePrivate(packageData.private);
 ```
 
 ### validateScripts(value)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 	"dependencies": {
 		"semver": "^7.7.2",
 		"validate-npm-package-license": "^3.0.4",
+		"validate-npm-package-name": "^7.0.0",
 		"yargs": "~18.0.0"
 	},
 	"devDependencies": {
@@ -75,6 +76,7 @@
 		"@types/node": "24.10.0",
 		"@types/semver": "7.7.0",
 		"@types/validate-npm-package-license": "3.0.3",
+		"@types/validate-npm-package-name": "^4.0.2",
 		"@types/yargs": "17.0.33",
 		"@vitest/coverage-v8": "4.0.4",
 		"@vitest/eslint-plugin": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       validate-npm-package-license:
         specifier: ^3.0.4
         version: 3.0.4
+      validate-npm-package-name:
+        specifier: ^7.0.0
+        version: 7.0.0
       yargs:
         specifier: ~18.0.0
         version: 18.0.0
@@ -36,6 +39,9 @@ importers:
       '@types/validate-npm-package-license':
         specifier: 3.0.3
         version: 3.0.3
+      '@types/validate-npm-package-name':
+        specifier: ^4.0.2
+        version: 4.0.2
       '@types/yargs':
         specifier: 17.0.33
         version: 17.0.33
@@ -983,6 +989,9 @@ packages:
 
   '@types/validate-npm-package-license@3.0.3':
     resolution: {integrity: sha512-uu5D5tHla4R+dEKKmF7NxlK4UHiEwqR8hgm1zF3ISBd5MnmNvTDYEcB77zEpAybHDEPgUVDFhOtU8V4LwuFGXg==}
+
+  '@types/validate-npm-package-name@4.0.2':
+    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3043,6 +3052,10 @@ packages:
     resolution: {integrity: sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  validate-npm-package-name@7.0.0:
+    resolution: {integrity: sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   vite@7.1.11:
     resolution: {integrity: sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3876,6 +3889,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/validate-npm-package-license@3.0.3': {}
+
+  '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6211,6 +6226,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validate-npm-package-name@7.0.0: {}
 
   validate-npm-package-name@7.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3052,10 +3052,6 @@ packages:
     resolution: {integrity: sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  validate-npm-package-name@7.0.0:
-    resolution: {integrity: sha512-bwVk/OK+Qu108aJcMAEiU4yavHUI7aN20TgZNBj9MR2iU1zPUl1Z1Otr7771ExfYTPTvfN8ZJ1pbr5Iklgt4xg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   vite@7.1.11:
     resolution: {integrity: sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6226,8 +6222,6 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
-
-  validate-npm-package-name@7.0.0: {}
 
   validate-npm-package-name@7.0.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
 	validateLicense,
 	validateMain,
 	validateMan,
+	validateName,
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -23,6 +23,7 @@ import {
 	validateLicense,
 	validateMain,
 	validateMan,
+	validateName,
 	validatePrivate,
 	validateScripts,
 	validateType,
@@ -95,9 +96,8 @@ const getSpecMap = (
 			main: { validate: (_, value) => validateMain(value).errorMessages },
 			man: { validate: (_, value) => validateMan(value).errorMessages },
 			name: {
-				format: packageFormat,
 				required: !isPrivate,
-				type: "string",
+				validate: (_, value) => validateName(value).errorMessages,
 			},
 			optionalDependencies: {
 				validate: (_, value) => validateDependencies(value).errorMessages,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -14,6 +14,7 @@ export { validateKeywords } from "./validateKeywords.ts";
 export { validateLicense } from "./validateLicense.ts";
 export { validateMain } from "./validateMain.ts";
 export { validateMan } from "./validateMan.ts";
+export { validateName } from "./validateName.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";

--- a/src/validators/validateName.test.ts
+++ b/src/validators/validateName.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { validateName } from "./validateName.ts";
+
+describe(validateName, () => {
+	it.each([
+		"some-package",
+		"example.com",
+		"under_score",
+		"123numeric",
+		"@scope/name",
+		"@scope/with.dot",
+	])("should return no issues for valid name '%s'", (license) => {
+		expect(validateName(license).errorMessages).toEqual([]);
+	});
+
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateName(123);
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateName({});
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is not a string (array)", () => {
+		const result = validateName([]);
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `Array`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateName(true);
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateName(undefined);
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateName(null);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateName("");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be a valid name",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateName("   ");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be a valid name",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it.each([
+		["excited!", [`name can no longer contain special characters ("~'!()*")`]],
+		[
+			" leading-space:and:weirdchars",
+			[
+				"name cannot contain leading or trailing spaces",
+				"name can only contain URL-friendly characters",
+			],
+		],
+		[
+			"eLaBorAtE-paCkAgE-with-mixed-case-and-more-than-214-characters-----------------------------------------------------------------------------------------------------------------------------------------------------------",
+			[
+				"name can no longer contain more than 214 characters",
+				"name can no longer contain capital letters",
+			],
+		],
+	])(
+		"should return an issue if the value is an invalid name (%s)",
+		(input, expected) => {
+			const result = validateName(input);
+			expect(result.errorMessages).toEqual(expected);
+		},
+	);
+});

--- a/src/validators/validateName.ts
+++ b/src/validators/validateName.ts
@@ -1,0 +1,31 @@
+import validate from "validate-npm-package-name";
+
+import { Result } from "../Result.ts";
+
+/**
+ * Validate the `name` field in a package.json, using `validate-npm-package-name`.
+ */
+export const validateName = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue("the value is empty, but should be a valid name");
+	} else {
+		const validationResults = validate(value);
+		for (const error of validationResults.errors ?? []) {
+			result.addIssue(error);
+		}
+		for (const warning of validationResults.warnings ?? []) {
+			result.addIssue(warning);
+		}
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #536
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateName` function that validates the value of the "name" field of a package.json. It returns a Result object with any issues detected.

The new function is much more accurate than the check that the monolithic `validate` function used to be doing.  It used its own bespoke regex pattern to detect a bad name.  The new function is using `validate-npm-package-name` to do it, which is the same package `npm` uses.
