### PR TITLE
feat: remove validations for deprecated / unsupported properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "package-json-validator",
-	"version": "0.51.0",
+	"version": "0.52.0",
 	"description": "Tools to validate package.json files.",
 	"keywords": [
 		"lint",

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -33,7 +33,7 @@ const npmWarningFields = {
 	bugs: "http://example.com/bugs",
 	description: "This is my description",
 	keywords: ["keyword1", "keyword2", "keyword3"],
-	licenses: [{ type: "MIT", url: "http://example.com/license" }],
+	license: "MIT",
 	repository: {
 		type: "git",
 		url: "git@github.com:JoshuaKGoldberg/package-json-validator.git",
@@ -305,10 +305,8 @@ describe("validate", () => {
 			}
 		});
 
-		test("Licenses", () => {
+		test("License", () => {
 			// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
-
-			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
 			let result = validate(JSON.stringify(json), {
 				recommendations: false,
@@ -318,21 +316,9 @@ describe("validate", () => {
 			assert.equal(result.critical, undefined, JSON.stringify(result));
 			assert.equal(result.warnings, undefined, JSON.stringify(result));
 
-			// licenses as a single type
+			// without the prop
 			json = getPackageJson(npmWarningFields);
-			delete json.licenses;
-			json.license = "MIT";
-			result = validate(JSON.stringify(json), {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings, undefined, JSON.stringify(result));
-
-			// neither
-			json = getPackageJson(npmWarningFields);
-			delete json.licenses;
+			delete json.license;
 			result = validate(JSON.stringify(json), {
 				recommendations: false,
 				warnings: true,
@@ -550,8 +536,6 @@ describe("validate", () => {
 
 		test("Licenses", () => {
 			// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
-
-			// licenses as an array
 			let json = getPackageJson(npmWarningFields);
 			let result = validate(json, {
 				recommendations: false,
@@ -561,21 +545,9 @@ describe("validate", () => {
 			assert.equal(result.critical, undefined, JSON.stringify(result));
 			assert.equal(result.warnings, undefined, JSON.stringify(result));
 
-			// licenses as a single type
+			// without the prop
 			json = getPackageJson(npmWarningFields);
-			delete json.licenses;
-			json.license = "MIT";
-			result = validate(json, {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings, undefined, JSON.stringify(result));
-
-			// neither
-			json = getPackageJson(npmWarningFields);
-			delete json.licenses;
+			delete json.license;
 			result = validate(json, {
 				recommendations: false,
 				warnings: true,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -75,7 +75,6 @@ const getSpecMap = (
 				recommended: true,
 				validate: (_, value) => validateEngines(value).errorMessages,
 			},
-			engineStrict: { type: "boolean" },
 			exports: { validate: (_, value) => validateExports(value).errorMessages },
 			files: { validate: (_, value) => validateFiles(value).errorMessages },
 			homepage: {
@@ -86,11 +85,8 @@ const getSpecMap = (
 				validate: (_, value) => validateKeywords(value).errorMessages,
 				warning: true,
 			},
-			license: { validate: (_, value) => validateLicense(value).errorMessages },
-			licenses: {
-				or: "license",
-				type: "array",
-				validate: validateUrlTypes,
+			license: {
+				validate: (_, value) => validateLicense(value).errorMessages,
 				warning: true,
 			},
 			main: { validate: (_, value) => validateMain(value).errorMessages },
@@ -106,11 +102,9 @@ const getSpecMap = (
 			peerDependencies: {
 				validate: (_, value) => validateDependencies(value).errorMessages,
 			},
-			preferGlobal: { type: "boolean" },
 			private: { validate: (_, value) => validatePrivate(value).errorMessages },
 			publishConfig: { type: "object" },
 			repository: {
-				or: "repositories",
 				types: ["string", "object"],
 				validate: validateUrlTypes,
 				warning: true,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #537
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes the following properties, which are no longer supported in modern versions of `npm`.

- engineStrict
- licenses
- preferGlobal
- repositories