### PR TITLE
feat(validateRepository): add function for validating `repository`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - remove validations for deprecated / unsupported properties ([#553](https://github.com/JoshuaKGoldberg/package-json-validator/issues/553)) ([8b1c558](https://github.com/JoshuaKGoldberg/package-json-validator/commit/8b1c5580ee1d04a710224ee3a99b89e784693e04)), closes [#537](https://github.com/JoshuaKGoldberg/package-json-validator/issues/537)
 - **validateName:** add function for validating `name` ([#551](https://github.com/JoshuaKGoldberg/package-json-validator/issues/551)) ([f984c4a](https://github.com/JoshuaKGoldberg/package-json-validator/commit/f984c4a62427d1f67e76c8f2bf0698627e2e61dd)), closes [#536](https://github.com/JoshuaKGoldberg/package-json-validator/issues/536)
 
+# [0.52.0](https://github.com/JoshuaKGoldberg/package-json-validator/compare/v0.51.0...v0.52.0) (2025-11-10)
+
+### Features
+
+- **validateEngines:** add function for validating `engines` ([#550](https://github.com/JoshuaKGoldberg/package-json-validator/issues/550)) ([eec9a3e](https://github.com/JoshuaKGoldberg/package-json-validator/commit/eec9a3ef8a03746a8f97724e3c1c88afa474ad96)), closes [#535](https://github.com/JoshuaKGoldberg/package-json-validator/issues/535)
+
 # [0.51.0](https://github.com/JoshuaKGoldberg/package-json-validator/compare/v0.50.0...v0.51.0) (2025-11-10)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -605,6 +605,45 @@ const packageData = {
 const result = validatePrivate(packageData.private);
 ```
 
+### validateRepository(value)
+
+This function validates the value of the `repository` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- It should be of type `object` or `string`.
+- If it's an `object`, it should have `type`, `url`, and optionally `directory`.
+- `type` and `directory` (if present) should be non-empty strings
+- `url` should be a valid repo url
+- If it's a `string`, it should be the shorthand repo string from a supported provider.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateRepository } from "package-json-validator";
+
+const packageData = {
+	repository: {
+		type: "git",
+		url: "git+https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		directory: "packages/package-json-validator",
+	},
+};
+
+const result = validateRepository(packageData.repository);
+```
+
+```ts
+import { validateRepository } from "package-json-validator";
+
+const packageData = {
+	repository: "github:JoshuaKGoldberg/package-json-validator",
+};
+
+const result = validateRepository(packageData.repository);
+```
+
 ### validateScripts(value)
 
 This function validates the value of the `scripts` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
 	validateDependencies as validateOptionalDependencies,
 	validateDependencies as validatePeerDependencies,
 	validatePrivate,
+	validateRepository,
 	validateScripts,
 	validateType,
 	validateVersion,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -25,6 +25,7 @@ import {
 	validateMan,
 	validateName,
 	validatePrivate,
+	validateRepository,
 	validateScripts,
 	validateType,
 	validateUrlOrMailto,
@@ -105,8 +106,7 @@ const getSpecMap = (
 			private: { validate: (_, value) => validatePrivate(value).errorMessages },
 			publishConfig: { type: "object" },
 			repository: {
-				types: ["string", "object"],
-				validate: validateUrlTypes,
+				validate: (_, value) => validateRepository(value).errorMessages,
 				warning: true,
 			},
 			scripts: { validate: (_, value) => validateScripts(value).errorMessages },

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -16,6 +16,7 @@ export { validateMain } from "./validateMain.ts";
 export { validateMan } from "./validateMan.ts";
 export { validateName } from "./validateName.ts";
 export { validatePrivate } from "./validatePrivate.ts";
+export { validateRepository } from "./validateRepository.ts";
 export { validateScripts } from "./validateScripts.ts";
 export { validateType } from "./validateType.ts";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.ts";

--- a/src/validators/validateRepository.test.ts
+++ b/src/validators/validateRepository.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+
+import { validateRepository } from "./validateRepository.ts";
+
+describe(validateRepository, () => {
+	it.each([
+		"git+https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		"https://github.com/JoshuaKGoldberg/package-json-validator",
+		"https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		"http://github.com/JoshuaKGoldberg/package-json-validator.git",
+		"git://github.com/JoshuaKGoldberg/package-json-validator.git",
+		"git://github.com/JoshuaKGoldberg/package-json-validator",
+		"git@github.com:JoshuaKGoldberg/package-json-validator.git",
+	])(
+		"should return no issues if the value is a valid object (with directory) (%s)",
+		(url) => {
+			const result = validateRepository({
+				directory: "packages/lib-a",
+				type: "git",
+				url,
+			});
+			expect(result.errorMessages).toEqual([]);
+			expect(result.childResults).toHaveLength(3);
+			result.childResults.forEach((childResult) => {
+				expect(childResult.issues).toHaveLength(0);
+			});
+		},
+	);
+
+	it("should return no issues if the value is a valid object (without directory)", () => {
+		const result = validateRepository({
+			type: "git",
+			url: "git+https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		});
+		expect(result.errorMessages).toEqual([]);
+		expect(result.childResults).toHaveLength(2);
+		result.childResults.forEach((childResult) => {
+			expect(childResult.issues).toHaveLength(0);
+		});
+	});
+
+	it.each([
+		"npm/example",
+		"github:npm/example",
+		"gist:11081aaa281",
+		"bitbucket:user/repo",
+		"gitlab:user/repo",
+	])(
+		"should return no issues if the value is a shorthand string: %s",
+		(value) => {
+			const result = validateRepository(value);
+			expect(result.errorMessages).toEqual([]);
+		},
+	);
+
+	it.each([
+		"svn:npm/example",
+		"eslint-plugin-package-json",
+		"git:npm/example",
+		"github:npm/example/repo",
+		"org/user/repo",
+	])(
+		"should return issues if the value is an invalid shorthand string: %s",
+		(value) => {
+			const result = validateRepository(value);
+			expect(result.errorMessages).toEqual([
+				`the value "${value}" is invalid; it should be the shorthand for a repository (e.g. "github:npm/example")`,
+			]);
+		},
+	);
+
+	it("should return an issue when the value is an empty string", () => {
+		const result = validateRepository("");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be repository shorthand string",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return issues if the value is an object with empty property values", () => {
+		const result = validateRepository({
+			directory: "",
+			type: "",
+			url: "",
+		});
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
+		[
+			[
+				`the value of property "directory" is empty, but should be the path to this package in the repository`,
+			],
+			[
+				`the value of property "type" is empty, but should be the type of repository this is (e.g. "git")`,
+			],
+			[
+				`the value of property "url" is invalid; it should be the url to a repository (e.g. "git+https://github.com/npm/cli.git")`,
+			],
+		].forEach((childErrors, i) => {
+			expect(result.childResults[i].errorMessages).toEqual(childErrors);
+		});
+	});
+
+	it("should return issues if the value is missing type and / or url", () => {
+		const result = validateRepository({
+			directory: "packages/lib-a",
+		});
+		expect(result.issues).toEqual([
+			{
+				message: `repository is missing property "type", which should be the type of repository this is (e.g. "git")`,
+			},
+			{
+				message: `repository is missing property "url", which should be the url to a repository (e.g. "git+https://github.com/npm/cli.git")`,
+			},
+		]);
+	});
+
+	it("should return issues if the value is an object with empty string keys", () => {
+		const result = validateRepository({
+			"": "packages/lib-a",
+			"  ": "git",
+			"    ":
+				"git+https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		});
+		expect(result.issues).toEqual([
+			{
+				message: `repository is missing property "type", which should be the type of repository this is (e.g. "git")`,
+			},
+			{
+				message: `repository is missing property "url", which should be the url to a repository (e.g. "git+https://github.com/npm/cli.git")`,
+			},
+		]);
+
+		expect(result.childResults).toHaveLength(3);
+		expect(result.childResults[0].errorMessages).toEqual([
+			'property 0 is invalid; keys should be "type", "url", and optionally "directory"',
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'property 1 is invalid; keys should be "type", "url", and optionally "directory"',
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			'property 2 is invalid; keys should be "type", "url", and optionally "directory"',
+		]);
+	});
+
+	it("should return issues if the value is an object with some properties having non-string values", () => {
+		const result = validateRepository({
+			type: "git",
+			url: 123,
+		});
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			'the value of property "url" should be a string',
+		]);
+	});
+
+	it("should return an issue if the value is neither an object nor a string", () => {
+		const result = validateRepository(123);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object` or `string`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the value is an array", () => {
+		const result = validateRepository([
+			"git",
+			"git+https://github.com/JoshuaKGoldberg/package-json-validator.git",
+		]);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object` or `string`, not `Array`",
+		]);
+	});
+
+	it("should return an issue if the value is null", () => {
+		const result = validateRepository(null);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an `object` or a `string`",
+		]);
+	});
+
+	it("should return an issue if the value is undefined", () => {
+		const result = validateRepository(undefined);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be `object` or `string`, not `undefined`",
+		]);
+	});
+});

--- a/src/validators/validateRepository.ts
+++ b/src/validators/validateRepository.ts
@@ -1,0 +1,160 @@
+import { ChildResult, Result } from "../Result.ts";
+
+type RepositoryValidator = (value: string) => Result;
+
+const validateNonEmptyString = (
+	value: string,
+	property: string,
+	description: string,
+) => {
+	const result = new Result();
+	if (value.trim() === "") {
+		result.addIssue(
+			`the value of property "${property}" is empty, but should be ${description}`,
+		);
+	}
+	return result;
+};
+
+const repoUrlRegex =
+	/^(?:(?:git\+)?(?:https?|git):\/\/[\w.-]+(?::\d+)?(?:\/[\w.~:/?#@!$&'()*+,;=%-]+)?(?:\.git)?\/?|git@[\w.-]+:[\w.~:/?#@!$&'()*+,;=%-]+\.git)$/;
+const repositoryValidators = {
+	directory: (value) =>
+		validateNonEmptyString(
+			value,
+			"directory",
+			"the path to this package in the repository",
+		),
+	type: (value) =>
+		validateNonEmptyString(
+			value,
+			"type",
+			'the type of repository this is (e.g. "git")',
+		),
+	url: (value: string) => {
+		const result = new Result();
+
+		// Should match the url regex
+		if (!repoUrlRegex.exec(value)) {
+			result.addIssue(
+				`the value of property "url" is invalid; it should be the url to a repository (e.g. "git+https://github.com/npm/cli.git")`,
+			);
+		}
+		return result;
+	},
+} satisfies Record<"directory" | "type" | "url", RepositoryValidator>;
+
+const KNOWN_PROVIDERS = ["bitbucket", "gist", "github", "gitlab"];
+const REPONAME_REGEX: Record<(typeof KNOWN_PROVIDERS)[number], RegExp> = {
+	bitbucket: /^\w+\/\w+$/,
+	gist: /^\w+$/,
+	github: /^\w+\/\w+$/,
+	gitlab: /^\w+\/\w+$/,
+};
+
+/**
+ * Should be of the form &lt;provider>:&lt;user>/&lt;repo>, or without the provider if the repo is from github.
+ */
+const isValidShorthandRepoString = (value: string): boolean => {
+	// It should either have no repo prefix, which means it's github, or should
+	// be prefixed by a known repo provider.
+	const parts = value.split(":");
+	let provider = "github";
+	let repo = parts[0];
+	if (parts.length > 1) {
+		provider = parts[0];
+		repo = parts[1];
+	}
+
+	if (!KNOWN_PROVIDERS.includes(provider)) {
+		return false;
+	}
+
+	// Repo name should match, based on the provider
+	if (!REPONAME_REGEX[provider].exec(repo)) {
+		return false;
+	}
+
+	return true;
+};
+
+/**
+ * Validate the `repository` field in a package.json, which can either be an object
+ * with `type`, `url`, and optionally `directory`, or a string with shorthand
+ * syntax to a supported repo.
+ *
+ * {
+ *  "type": "git",
+ *  "url": "git+https://github.com/npm/cli.git",
+ *  "directory": "packages/lib-a"
+ * }
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository
+ */
+export const validateRepository = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (typeof obj === "string") {
+		if (obj.trim() === "") {
+			result.addIssue(
+				"the value is empty, but should be repository shorthand string",
+			);
+		} else if (!isValidShorthandRepoString(obj)) {
+			result.addIssue(
+				`the value "${obj}" is invalid; it should be the shorthand for a repository (e.g. "github:npm/example")`,
+			);
+		}
+	} else if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+		const seenProperties = new Set<string>();
+		let propertyNumber = 0;
+		for (const [key, value] of Object.entries(obj)) {
+			const childResult = new ChildResult(propertyNumber);
+			const normalizedKey = key.trim();
+			const propertyName =
+				normalizedKey === "" ? String(propertyNumber) : `"${normalizedKey}"`;
+
+			if (key === "directory" || key === "type" || key === "url") {
+				seenProperties.add(key);
+
+				if (typeof value !== "string") {
+					childResult.addIssue(
+						`the value of property ${propertyName} should be a string`,
+					);
+				} else {
+					const propertyResult = repositoryValidators[key](value);
+					propertyResult.issues.forEach((issue) => {
+						childResult.addIssue(issue.message);
+					});
+				}
+			} else {
+				childResult.addIssue(
+					`property ${propertyName} is invalid; keys should be "type", "url", and optionally "directory"`,
+				);
+			}
+			result.addChildResult(childResult);
+			propertyNumber++;
+		}
+
+		// the object should at least have `type` and `url`.
+		if (!seenProperties.has("type")) {
+			result.addIssue(
+				`repository is missing property "type", which should be the type of repository this is (e.g. "git")`,
+			);
+		}
+		if (!seenProperties.has("url")) {
+			result.addIssue(
+				`repository is missing property "url", which should be the url to a repository (e.g. "git+https://github.com/npm/cli.git")`,
+			);
+		}
+	} else if (obj === null) {
+		result.addIssue(
+			"the value is `null`, but should be an `object` or a `string`",
+		);
+	} else {
+		const valueType = Array.isArray(obj) ? "Array" : typeof obj;
+		result.addIssue(
+			`the type should be \`object\` or \`string\`, not \`${valueType}\``,
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #538
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateRepository` function that validates the value of the "repository" field of a package.json. It returns a Result object with any issues detected.

The new function is much more accurate than the check that the monolithic `validate` function used to be doing.