### PR TITLE
chore: enable `vitest/prefer-describe-function-title`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,7 +89,10 @@ export default defineConfig(
 	{
 		extends: [vitest.configs.recommended],
 		files: ["**/*.test.*"],
-		rules: { "@typescript-eslint/no-unsafe-assignment": "off" },
+		rules: {
+			"@typescript-eslint/no-unsafe-assignment": "off",
+			"vitest/prefer-describe-function-title": "error",
+		},
 	},
 	{
 		extends: [yml.configs["flat/standard"], yml.configs["flat/prettier"]],

--- a/src/Result.test.ts
+++ b/src/Result.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { ChildResult, Result } from "./Result.ts";
 
-describe("Result", () => {
-	describe("Result", () => {
+describe(Result, () => {
+	describe(Result, () => {
 		describe("constructor", () => {
 			it("should create a Result with no issues by default", () => {
 				const result = new Result();
@@ -173,7 +173,7 @@ describe("Result", () => {
 		});
 	});
 
-	describe("ChildResult", () => {
+	describe(ChildResult, () => {
 		describe("constructor", () => {
 			it("should create a ChildResult with no issues by default", () => {
 				const childResult = new ChildResult(0);

--- a/src/utils/validateFieldType.test.ts
+++ b/src/utils/validateFieldType.test.ts
@@ -4,7 +4,7 @@ import type { FieldSpec } from "../Spec.types.ts";
 
 import { validateFieldType } from "./validateFieldType.ts";
 
-describe("validateFieldType", () => {
+describe(validateFieldType, () => {
 	it("should return an empty array if no type or types are defined", () => {
 		const field = {} satisfies FieldSpec;
 		const result = validateFieldType("testField", field, "testValue");

--- a/src/utils/validatePeople.test.ts
+++ b/src/utils/validatePeople.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { isPerson, isPersonArray, validatePeople } from "./validatePeople.ts";
 
-describe("validatePeople", () => {
+describe(validatePeople, () => {
 	it("should validate string with only name", () => {
 		const result = validatePeople("Barney Rubble");
 		expect(result.errorMessages).toEqual([]);
@@ -167,7 +167,7 @@ describe("validatePeople", () => {
 		expect(result.issues.length).toBe(1);
 	});
 
-	describe("isPerson", () => {
+	describe(isPerson, () => {
 		it("should return true for valid person object", () => {
 			const person = { name: "Barney Rubble" };
 			expect(isPerson(person)).toBe(true);
@@ -189,7 +189,7 @@ describe("validatePeople", () => {
 		);
 	});
 
-	describe("isPersonArray", () => {
+	describe(isPersonArray, () => {
 		it("should return true for valid person array", () => {
 			const personArray = [
 				{ name: "Barney Rubble" },

--- a/src/utils/validateUrlTypes.test.ts
+++ b/src/utils/validateUrlTypes.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateUrlTypes } from "./validateUrlTypes.ts";
 
-describe("validateUrlTypes", () => {
+describe(validateUrlTypes, () => {
 	it("should return an error if the string is not a valid URL", () => {
 		const result = validateUrlTypes("testField", "invalidUrl");
 		expect(result).toEqual(["URL not valid for testField: invalidUrl"]);

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -45,7 +45,7 @@ const npmWarningFields = {
 	},
 };
 
-describe("validate", () => {
+describe(validate, () => {
 	describe("Basic", () => {
 		test("Input types", () => {
 			assert.ok(validate("string").critical, "string");

--- a/src/validators/validateAuthor.test.ts
+++ b/src/validators/validateAuthor.test.ts
@@ -9,7 +9,7 @@ vi.mock("../utils/validatePeople", () => ({
 	validatePeople: vi.fn(),
 }));
 
-describe("validateAuthor", () => {
+describe(validateAuthor, () => {
 	beforeEach(() => {
 		vi.restoreAllMocks();
 	});

--- a/src/validators/validateBin.test.ts
+++ b/src/validators/validateBin.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateBin } from "./validateBin.ts";
 
-describe("validateBin", () => {
+describe(validateBin, () => {
 	it("should return a Result with no issues if the bin field is an empty object", () => {
 		const result = validateBin({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateBundleDependencies.test.ts
+++ b/src/validators/validateBundleDependencies.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateBundleDependencies } from "./validateBundleDependencies.ts";
 
-describe("validateBundleDependencies", () => {
+describe(validateBundleDependencies, () => {
 	it("should return a result with no issues if the value is an empty array", () => {
 		const result = validateBundleDependencies([]);
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateConfig.test.ts
+++ b/src/validators/validateConfig.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateConfig } from "./validateConfig.ts";
 
-describe("validateConfig", () => {
+describe(validateConfig, () => {
 	it("should return a result with no issues if the field is an empty object", () => {
 		const result = validateConfig({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateCpu.test.ts
+++ b/src/validators/validateCpu.test.ts
@@ -16,7 +16,7 @@ const VALID_ARCHS = [
 	"x64",
 ];
 
-describe("validateCpu", () => {
+describe(validateCpu, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateCpu([]);
 

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateDependencies } from "./validateDependencies.ts";
 
-describe("validateDependencies", () => {
+describe(validateDependencies, () => {
 	it("should return no errors if the value is an empty object", () => {
 		const result = validateDependencies({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateDescription.test.ts
+++ b/src/validators/validateDescription.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateDescription } from "./validateDescription.ts";
 
-describe("validateDescription", () => {
+describe(validateDescription, () => {
 	it("should return no issues for a string", () => {
 		const result = validateDescription("The Fragile");
 

--- a/src/validators/validateDirectories.test.ts
+++ b/src/validators/validateDirectories.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateDirectories } from "./validateDirectories.ts";
 
-describe("validateDirectories", () => {
+describe(validateDirectories, () => {
 	it("should return no issues if the value is an empty object", () => {
 		const result = validateDirectories({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateExports.test.ts
+++ b/src/validators/validateExports.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateExports } from "./validateExports.ts";
 
-describe("validateExports", () => {
+describe(validateExports, () => {
 	it("should return no issues if the value is an empty object", () => {
 		const result = validateExports({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateFiles.test.ts
+++ b/src/validators/validateFiles.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateFiles } from "./validateFiles.ts";
 
-describe("validateFiles", () => {
+describe(validateFiles, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateFiles([]);
 

--- a/src/validators/validateHomepage.test.ts
+++ b/src/validators/validateHomepage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateHomepage } from "./validateHomepage.ts";
 
-describe("validateHomepage", () => {
+describe(validateHomepage, () => {
 	it("should return no issues for a valid url", () => {
 		let result = validateHomepage("https://nin.com");
 

--- a/src/validators/validateKeywords.test.ts
+++ b/src/validators/validateKeywords.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { ChildResult, Result } from "../Result.ts";
 import { validateKeywords } from "./validateKeywords.ts";
 
-describe("validateKeywords", () => {
+describe(validateKeywords, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateKeywords([]);
 

--- a/src/validators/validateLicense.test.ts
+++ b/src/validators/validateLicense.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateLicense } from "./validateLicense.ts";
 
-describe("validateLicense", () => {
+describe(validateLicense, () => {
 	it.each([
 		"MIT",
 		"BSD-2-Clause",

--- a/src/validators/validateMain.test.ts
+++ b/src/validators/validateMain.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateMain } from "./validateMain.ts";
 
-describe("validateMain", () => {
+describe(validateMain, () => {
 	it("should return no issues for a string", () => {
 		const result = validateMain("index.js");
 

--- a/src/validators/validateMan.test.ts
+++ b/src/validators/validateMan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateMan } from "./validateMan.ts";
 
-describe("validateMan", () => {
+describe(validateMan, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateMan([]);
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateOs.test.ts
+++ b/src/validators/validateOs.test.ts
@@ -13,7 +13,7 @@ const VALID_OSS = [
 	"win32",
 ];
 
-describe("validateOs", () => {
+describe(validateOs, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateOs([]);
 

--- a/src/validators/validatePrivate.test.ts
+++ b/src/validators/validatePrivate.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validatePrivate } from "./validatePrivate.ts";
 
-describe("validatePrivate", () => {
+describe(validatePrivate, () => {
 	it.each([true, false])(
 		"should return no issues for boolean values '%s'",
 		(type) => {

--- a/src/validators/validatePublishConfig.test.ts
+++ b/src/validators/validatePublishConfig.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validatePublishConfig } from "./validatePublishConfig.ts";
 
-describe("validatePublishConfig", () => {
+describe(validatePublishConfig, () => {
 	it("should return no issues if the value is an empty object", () => {
 		const result = validatePublishConfig({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateScripts.test.ts
+++ b/src/validators/validateScripts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateScripts } from "./validateScripts.ts";
 
-describe("validateScripts", () => {
+describe(validateScripts, () => {
 	it("should return no issues if the scripts field is an empty object", () => {
 		const result = validateScripts({});
 		expect(result.errorMessages).toEqual([]);

--- a/src/validators/validateType.test.ts
+++ b/src/validators/validateType.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateType } from "./validateType.ts";
 
-describe("validateType", () => {
+describe(validateType, () => {
 	it.each(["commonjs", "module"])(
 		"should return no issues for valid type '%s'",
 		(type) => {

--- a/src/validators/validateUrlOrMailto.test.ts
+++ b/src/validators/validateUrlOrMailto.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateUrlOrMailto } from "./validateUrlOrMailto.ts";
 
-describe("validateUrlOrMailto", () => {
+describe(validateUrlOrMailto, () => {
 	it("should return an error if the string is neither a valid URL nor a valid email", () => {
 		const result = validateUrlOrMailto("testField", "invalidString");
 		expect(result).toEqual(["testField should be an email or a url"]);

--- a/src/validators/validateVersion.test.ts
+++ b/src/validators/validateVersion.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateVersion } from "./validateVersion.ts";
 
-describe("validateVersion", () => {
+describe(validateVersion, () => {
 	it.each([
 		"1.2.3",
 		"1.2.3-beta.0",

--- a/src/validators/validateWorkspaces.test.ts
+++ b/src/validators/validateWorkspaces.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { validateWorkspaces } from "./validateWorkspaces.ts";
 
-describe("validateWorkspaces", () => {
+describe(validateWorkspaces, () => {
 	it("should return no issues if the value is an empty array", () => {
 		const result = validateWorkspaces([]);
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #549
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change enables vitest's `prefer-describe-function-title` rule, and applies autofixes to all existing violations.
