### PR TITLE
feat(validateContributors): add function for validating `contributors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,35 @@ const packageData = {
 const result = validateConfig(packageData.config);
 ```
 
+### validateContributors(value)
+
+This function validates the value of the `contributors` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an `Array` of objects
+- each object in the array should be a "person" object with at least a `name` and optionally `email` and `url`
+- the `email` and `url` properties, if present, should be valid email and URL formats.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateContributors } from "package-json-validator";
+
+const packageData = {
+	contributors: [
+		{
+			email: "b@rubble.com",
+			name: "Barney Rubble",
+			url: "http://barnyrubble.tumblr.com/",
+		},
+	],
+};
+
+const result = validateContributors(packageData.contributors);
+```
+
 ### validateCpu(value)
 
 This function validates the value of the `cpu` property of a `package.json`.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
 			"name": "JoshuaKGoldberg",
 			"email": "npm@joshuakgoldberg.com",
 			"url": "https://joshuakgoldberg.com"
+		},
+		{
+			"name": "michael faith",
+			"email": "michaelfaith@users.noreply.github.com",
+			"url": "https://michael.faith"
 		}
 	],
 	"type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
 	validateBin,
 	validateBundleDependencies,
 	validateConfig,
+	validateContributors,
 	validateCpu,
 	validateDependencies,
 	validateDescription,

--- a/src/utils/validatePeople.ts
+++ b/src/utils/validatePeople.ts
@@ -65,12 +65,12 @@ function validatePerson(obj: Person | string): Result {
  *   "url" : "http://barnyrubble.tumblr.com/"
  * }
  *
+ * An array of such objects.
  * Or a single string like this:
  * "Barney Rubble &lt;b@rubble.com> (http://barnyrubble.tumblr.com/)
- * Or an array of either of the above.
  */
 export const validatePeople = (obj: People): Result => {
-	if (obj instanceof Array) {
+	if (Array.isArray(obj)) {
 		const result = new Result();
 		for (let i = 0; i < obj.length; i++) {
 			result.addChildResult(i, validatePerson(obj[i]));

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -8,6 +8,7 @@ const getPackageJson = (
 	config: {
 		debug: true,
 	},
+	contributors: [{ name: "Efrim Manuel Menuck" }],
 	cpu: ["x64", "ia32"],
 	directories: {
 		bin: "dist/bin",

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -11,6 +11,7 @@ import {
 	validateBin,
 	validateBundleDependencies,
 	validateConfig,
+	validateContributors,
 	validateCpu,
 	validateDependencies,
 	validateDescription,
@@ -57,7 +58,7 @@ const getSpecMap = (
 			},
 			config: { validate: (_, value) => validateConfig(value).errorMessages },
 			contributors: {
-				validate: (_, value) => validatePeople(value).errorMessages,
+				validate: (_, value) => validateContributors(value).errorMessages,
 			},
 			cpu: { validate: (_, value) => validateCpu(value).errorMessages },
 			dependencies: {

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -2,6 +2,7 @@ export { validateAuthor } from "./validateAuthor.ts";
 export { validateBin } from "./validateBin.ts";
 export { validateBundleDependencies } from "./validateBundleDependencies.ts";
 export { validateConfig } from "./validateConfig.ts";
+export { validateContributors } from "./validateContributors.ts";
 export { validateCpu } from "./validateCpu.ts";
 export { validateDependencies } from "./validateDependencies.ts";
 export { validateDescription } from "./validateDescription.ts";

--- a/src/validators/validateContributors.test.ts
+++ b/src/validators/validateContributors.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Result } from "../Result.ts";
+import { validatePeople } from "../utils/index.ts";
+import { validateContributors } from "./validateContributors.ts";
+
+vi.mock("../utils/validatePeople", async () => ({
+	...(await vi.importActual("../utils/validatePeople")),
+	validatePeople: vi.fn(),
+}));
+
+describe(validateContributors, () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("should call validatePeople with objects", () => {
+		const barney = {
+			email: "b@rubble.com",
+			name: "Barney Rubble",
+			url: "http://barnyrubble.tumblr.com/",
+		};
+		const fred = {
+			email: "f@flintstone.com",
+			name: "Fred Flintstone",
+			url: "http://fflintstone.tumblr.com/",
+		};
+		const mockValidatePeople = vi
+			.mocked(validatePeople)
+			.mockReturnValue(new Result());
+
+		const result = validateContributors([barney, fred]);
+
+		expect(mockValidatePeople).toHaveBeenNthCalledWith(1, barney);
+		expect(mockValidatePeople).toHaveBeenNthCalledWith(2, fred);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return an issue if the input is not an array", () => {
+		const result = validateContributors(123);
+		expect(result.issues).toHaveLength(1);
+		expect(result.errorMessages).toEqual([
+			"the type should be an `Array` of objects with at least a `name` property, and optionally `email` and `url`",
+		]);
+		expect(validatePeople).not.toHaveBeenCalled();
+	});
+
+	it("should return issues if any of the contributors aren't valid people objects", () => {
+		const barney = {
+			email: "b@rubble.com",
+			name: "Barney Rubble",
+			url: "http://barnyrubble.tumblr.com/",
+		};
+		const fred = {
+			email: "f@flintstone.com",
+		};
+		const contributors = [barney, fred];
+		const mockValidatePeople = vi
+			.mocked(validatePeople)
+			.mockReturnValue(new Result());
+
+		const result = validateContributors(contributors);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		expect(result.errorMessages).toEqual([
+			"item 1 is invalid; it should be a person object with at least a \`name\`",
+		]);
+		expect(mockValidatePeople).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/validators/validateContributors.ts
+++ b/src/validators/validateContributors.ts
@@ -1,0 +1,38 @@
+import { Result } from "../Result.ts";
+import { isPerson, validatePeople } from "../utils/index.ts";
+
+/**
+ * Validate the `contributors` field in a package.json, which should be an array
+ * consisting of objects with `name` and optionally, `email` and `url` fields.
+ * The `email` and `url` fields, if present, should be valid email and URL formats.
+ *
+ * [
+ *   {
+ *     "name" : "Barney Rubble"
+ *     "email" : "b@rubble.com",
+ *     "url" : "http://barnyrubble.tumblr.com/"
+ *   }
+ * ]
+ */
+export const validateContributors = (obj: unknown): Result => {
+	const result = new Result();
+	if (Array.isArray(obj)) {
+		for (let i = 0; i < obj.length; i++) {
+			let childResult: Result;
+			const item = obj[i];
+			if (!isPerson(item)) {
+				childResult = new Result([
+					`item ${i} is invalid; it should be a person object with at least a \`name\``,
+				]);
+			} else {
+				childResult = validatePeople(item);
+			}
+			result.addChildResult(i, childResult);
+		}
+	} else {
+		result.addIssue(
+			"the type should be an `Array` of objects with at least a `name` property, and optionally `email` and `url`",
+		);
+	}
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #555
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateContributors` function that validates the value of the "contributors" field of a package.json. It returns a Result object with any issues detected.

This new function is just a wrapper around the `validatePeople` function and does some initial type validation before calling.
