### PR TITLE
feat(validateSideEffects): add function for validating `sideEffects`

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ This function validates the value of the `sideEffects` property of a `package.js
 It takes the value, and validates it against the following criteria.
 
 - The value is either a boolean or an Array.
-- If it's an array, all items should be non-emptry strings.
+- If it's an array, all items should be non-empty strings.
 
 It returns a `Result` object (See [Result Types](#result-types)).
 

--- a/README.md
+++ b/README.md
@@ -771,6 +771,28 @@ const packageData = {
 const result = validateScripts(packageData.scripts);
 ```
 
+### validateSideEffects(value)
+
+This function validates the value of the `sideEffects` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- The value is either a boolean or an Array.
+- If it's an array, all items should be non-emptry strings.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateSideEffects } from "package-json-validator";
+
+const packageData = {
+	sideEffects: false,
+};
+
+const result = validateSideEffects(packageData.sideEffects);
+```
+
 ### validateType(value)
 
 This function validates the value of the `type` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
 	validatePublishConfig,
 	validateRepository,
 	validateScripts,
+	validateSideEffects,
 	validateType,
 	validateVersion,
 	validateWorkspaces,

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -28,6 +28,7 @@ const getPackageJson = (
 	scripts: {
 		lint: "eslint .",
 	},
+	sideEffects: false,
 	type: "module",
 	version: "0.5.0",
 	workspaces: ["./packages/*"],

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -30,6 +30,7 @@ import {
 	validatePublishConfig,
 	validateRepository,
 	validateScripts,
+	validateSideEffects,
 	validateType,
 	validateUrlOrMailto,
 	validateVersion,
@@ -115,6 +116,9 @@ const getSpecMap = (
 				warning: true,
 			},
 			scripts: { validate: (_, value) => validateScripts(value).errorMessages },
+			sideEffects: {
+				validate: (_, value) => validateSideEffects(value).errorMessages,
+			},
 			type: {
 				recommended: true,
 				validate: (_, value) => validateType(value).errorMessages,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -21,6 +21,7 @@ export { validatePrivate } from "./validatePrivate.ts";
 export { validatePublishConfig } from "./validatePublishConfig.ts";
 export { validateRepository } from "./validateRepository.ts";
 export { validateScripts } from "./validateScripts.ts";
+export { validateSideEffects } from "./validateSideEffects.ts";
 export { validateType } from "./validateType.ts";
 export { validateUrlOrMailto } from "./validateUrlOrMailto.ts";
 export { validateVersion } from "./validateVersion.ts";

--- a/src/validators/validateEngines.test.ts
+++ b/src/validators/validateEngines.test.ts
@@ -8,7 +8,7 @@ describe(validateEngines, () => {
 		expect(result.errorMessages).toEqual([]);
 	});
 
-	it("should return issues if the value is an object with all keys having valid string values", () => {
+	it("should return no issues if the value is an object with all keys having valid string values", () => {
 		const result = validateEngines({
 			node: "^24.11.0",
 			npm: "Please use pnpm",

--- a/src/validators/validatePrivate.test.ts
+++ b/src/validators/validatePrivate.test.ts
@@ -27,11 +27,11 @@ describe(validatePrivate, () => {
 		]);
 	});
 
-	it("should return error if type is not a boolean (array)", () => {
+	it("should return error if type is not a boolean (Array)", () => {
 		const result = validatePrivate([]);
 
 		expect(result.errorMessages).toEqual([
-			"the type should be a `boolean`, not `array`",
+			"the type should be a `boolean`, not `Array`",
 		]);
 	});
 

--- a/src/validators/validatePrivate.ts
+++ b/src/validators/validatePrivate.ts
@@ -10,7 +10,7 @@ export const validatePrivate = (type: unknown): Result => {
 		if (type === null) {
 			result.addIssue("the value is `null`, but should be a `boolean`");
 		} else {
-			const valueType = Array.isArray(type) ? "array" : typeof type;
+			const valueType = Array.isArray(type) ? "Array" : typeof type;
 			result.addIssue(`the type should be a \`boolean\`, not \`${valueType}\``);
 		}
 	}

--- a/src/validators/validateSideEffects.test.ts
+++ b/src/validators/validateSideEffects.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { validateSideEffects } from "./validateSideEffects.ts";
+
+describe(validateSideEffects, () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateSideEffects([]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is a boolean", () => {
+		let result = validateSideEffects(true);
+		expect(result.errorMessages).toEqual([]);
+
+		result = validateSideEffects(false);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is a valid array with all strings", () => {
+		const result = validateSideEffects([
+			"./dist/polyfill.js",
+			"./dist/legacy.js",
+		]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return issues if the value is an array with some non-string values", () => {
+		const result = validateSideEffects([
+			"./dist/polyfill.js",
+			null,
+			"./dist/legacy.js",
+			123,
+		]);
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+		]);
+		expect(result.childResults[3].errorMessages).toEqual([
+			"item at index 3 should be a string, not `number`",
+		]);
+	});
+
+	it("should return a result with issues if the value is an array with non-empty strings", () => {
+		const result = validateSideEffects([
+			"",
+			"./dist/polyfill.js",
+			"",
+			"./dist/legacy.js",
+		]);
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be a path to a file with side effects or a glob pattern",
+			"item at index 2 is empty, but should be a path to a file with side effects or a glob pattern",
+		]);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"item at index 0 is empty, but should be a path to a file with side effects or a glob pattern",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"item at index 2 is empty, but should be a path to a file with side effects or a glob pattern",
+		]);
+	});
+
+	it("should return issues if the value is a number", () => {
+		const result = validateSideEffects(123);
+		expect(result.errorMessages).toEqual([
+			"the type should be `boolean` or `Array`, not `number`",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return a result with issues if the value is an object", () => {
+		const result = validateSideEffects({});
+		expect(result.issues).toEqual([
+			{ message: "the type should be `boolean` or `Array`, not `object`" },
+		]);
+	});
+
+	it("should return a result with issues if the value is null", () => {
+		const result = validateSideEffects(null);
+		expect(result.issues).toEqual([
+			{
+				message: "the value is `null`, but should be a `boolean` or an `Array`",
+			},
+		]);
+	});
+});

--- a/src/validators/validateSideEffects.ts
+++ b/src/validators/validateSideEffects.ts
@@ -1,0 +1,42 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * Validate the `sideEffects` property in a package.json, which can either be
+ * a boolean or an array of non-empty strings.
+ *@see https://webpack.js.org/guides/tree-shaking/#with-sideeffects-false-in-packagejson
+ */
+export const validateSideEffects = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value === "boolean") {
+		return result; // No errors for boolean
+	} else if (Array.isArray(value)) {
+		// If it's an array, check if all items are non-empty strings
+		for (let i = 0; i < value.length; i++) {
+			const childResult = new ChildResult(i);
+			const item = value[i];
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be a path to a file with side effects or a glob pattern`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (value == null) {
+		result.addIssue(
+			"the value is `null`, but should be a `boolean` or an `Array`",
+		);
+	} else {
+		const valueType = typeof value;
+		result.addIssue(
+			`the type should be \`boolean\` or \`Array\`, not \`${valueType}\``,
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #570
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateSideEffects` function that validates the value of the "sideEffects" field of a package.json. It returns a Result object with any issues detected.

This is an entirely new validation for this package.  It checks that the value is either a `boolean` or an `Array` of non-empty strings.
