### PR TITLE
build: add `files` to all eslint config objects

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,28 @@ export default defineConfig(
 			regexp.configs["flat/recommended"],
 		],
 		files: JS_TS_FILES,
+		rules: {
+			"@typescript-eslint/consistent-type-imports": "error",
+			"n/no-missing-import": "off",
+
+			// Using a ts bin file throws this rule off.
+			// It uses the package.json as a source of truth, and since the package points
+			// at the transpiled js file, it treats usage on the ts src as a violation.
+			"n/hashbang": "off",
+
+			// Stylistic concerns that don't interfere with Prettier
+			"logical-assignment-operators": [
+				"error",
+				"always",
+				{ enforceForIfStatements: true },
+			],
+			"no-useless-rename": "error",
+			"object-shorthand": "error",
+			"operator-assignment": "error",
+		},
+		settings: {
+			perfectionist: { partitionByComment: true, type: "natural" },
+		},
 	},
 	{
 		extends: [
@@ -45,6 +67,9 @@ export default defineConfig(
 			jsdoc.configs["flat/stylistic-typescript-error"],
 		],
 		files: TS_FILES,
+		rules: {
+			"jsdoc/match-description": "off",
+		},
 	},
 	{
 		extends: [jsonc.configs["flat/recommended-with-json"]],
@@ -69,40 +94,14 @@ export default defineConfig(
 			},
 		},
 		rules: {
-			"@typescript-eslint/consistent-type-imports": "error",
 			"@typescript-eslint/no-deprecated": "off",
 			"@typescript-eslint/no-dynamic-delete": "off",
 			"@typescript-eslint/restrict-template-expressions": "off",
-			"jsdoc/match-description": "off",
-			"n/no-missing-import": "off",
 
-			// Using a ts bin file throws this rule off.
-			// It uses the package.json as a source of truth, and since the package points
-			// at the transpiled js file, it treats usage on the ts src as a violation.
-			"n/hashbang": "off",
-
-			// TODO: Eventually clean these up
-			"@typescript-eslint/no-unsafe-argument": "off",
-			"@typescript-eslint/no-unsafe-assignment": "off",
+			// TODO: Eventually clean this up
 			"@typescript-eslint/no-unsafe-member-access": "off",
-			"@typescript-eslint/no-unsafe-return": "off",
-			"no-useless-escape": "off",
-			"regexp/no-super-linear-backtracking": "off",
-			"regexp/no-unused-capturing-group": "off",
-			"regexp/no-useless-quantifier": "off",
-
-			// Stylistic concerns that don't interfere with Prettier
-			"logical-assignment-operators": [
-				"error",
-				"always",
-				{ enforceForIfStatements: true },
-			],
-			"no-useless-rename": "error",
-			"object-shorthand": "error",
-			"operator-assignment": "error",
 		},
 		settings: {
-			perfectionist: { partitionByComment: true, type: "natural" },
 			vitest: { typecheck: true },
 		},
 	},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,10 @@ import yml from "eslint-plugin-yml";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
+const JS_FILES = ["**/*.js", "**/*.mjs"];
+const TS_FILES = ["**/*.ts", "**/*.mts"];
+const JS_TS_FILES = [...JS_FILES, ...TS_FILES];
+
 export default defineConfig(
 	{
 		ignores: [
@@ -24,22 +28,38 @@ export default defineConfig(
 		],
 	},
 	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
-	eslint.configs.recommended,
-	comments.recommended,
-	jsdoc.configs["flat/contents-typescript-error"],
-	jsdoc.configs["flat/logical-typescript-error"],
-	jsdoc.configs["flat/stylistic-typescript-error"],
-	jsonc.configs["flat/recommended-with-json"],
-	n.configs["flat/recommended"],
-	packageJson.configs.recommended,
-	perfectionist.configs["recommended-natural"],
-	regexp.configs["flat/recommended"],
+	{
+		extends: [
+			eslint.configs.recommended,
+			comments.recommended,
+			n.configs["flat/recommended"],
+			perfectionist.configs["recommended-natural"],
+			regexp.configs["flat/recommended"],
+		],
+		files: JS_TS_FILES,
+	},
+	{
+		extends: [
+			jsdoc.configs["flat/contents-typescript-error"],
+			jsdoc.configs["flat/logical-typescript-error"],
+			jsdoc.configs["flat/stylistic-typescript-error"],
+		],
+		files: TS_FILES,
+	},
+	{
+		extends: [jsonc.configs["flat/recommended-with-json"]],
+		files: ["**/*.json", "**/*.jsonc"],
+	},
+	{
+		extends: [packageJson.configs["recommended-publishable"]],
+		files: ["package.json"],
+	},
 	{
 		extends: [
 			tseslint.configs.strictTypeChecked,
 			tseslint.configs.stylisticTypeChecked,
 		],
-		files: ["**/*.{js,mjs,ts}"],
+		files: JS_TS_FILES,
 		languageOptions: {
 			parserOptions: {
 				projectService: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,8 +11,8 @@ import yml from "eslint-plugin-yml";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
-const JS_FILES = ["**/*.js", "**/*.mjs"];
-const TS_FILES = ["**/*.ts", "**/*.mts"];
+const JS_FILES = ["**/*.js"];
+const TS_FILES = ["**/*.ts"];
 const JS_TS_FILES = [...JS_FILES, ...TS_FILES];
 
 export default defineConfig(

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 			"url": "https://michael.faith"
 		}
 	],
+	"sideEffects": false,
 	"type": "module",
 	"exports": {
 		".": {
@@ -90,7 +91,7 @@
 		"eslint-plugin-jsdoc": "61.1.0",
 		"eslint-plugin-jsonc": "2.21.0",
 		"eslint-plugin-n": "17.23.1",
-		"eslint-plugin-package-json": "0.65.0",
+		"eslint-plugin-package-json": "~0.85.0",
 		"eslint-plugin-perfectionist": "4.15.0",
 		"eslint-plugin-regexp": "2.10.0",
 		"eslint-plugin-yml": "1.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: 17.23.1
         version: 17.23.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint-plugin-package-json:
-        specifier: 0.65.0
-        version: 0.65.0(@types/estree@1.0.8)(eslint@9.39.1(jiti@2.6.1))(jsonc-eslint-parser@2.4.0)
+        specifier: ~0.85.0
+        version: 0.85.0(@types/estree@1.0.8)(eslint@9.39.1(jiti@2.6.1))(jsonc-eslint-parser@2.4.0)
       eslint-plugin-perfectionist:
         specifier: 4.15.0
         version: 4.15.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
@@ -1738,8 +1738,8 @@ packages:
     peerDependencies:
       eslint: '>=8.23.0'
 
-  eslint-plugin-package-json@0.65.0:
-    resolution: {integrity: sha512-uCrnZBdMowAkewhMVZebTnoLN5gJwBSi3L8060ZovAMc0qPPUJle8IT5G1wHyddcQziyzlxt94khbEcn7zzdig==}
+  eslint-plugin-package-json@0.85.0:
+    resolution: {integrity: sha512-MrOxFvhbqLuk4FIPG9v3u9Amn0n137J8LKILHvgfxK3rRyAHEVzuZM0CtpXFTx7cx4LzmAzONtlpjbM0UFNuTA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       eslint: '>=8.0.0'
@@ -2577,8 +2577,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.34.0:
-    resolution: {integrity: sha512-kij4ALmQrfqNBPgfgTs3c6mbGwpG0M3Di8dtkt9RFXg73cFKxberr7SW0kwMHgJ8PNVq+QnOP12p7TFzMxgJZw==}
+  package-json-validator@0.59.0:
+    resolution: {integrity: sha512-WBTDKtO9pBa9GmA1sPbQHqlWxRdnHNfLFIIA49PPgV7px/rG27gHX57DWy77qyu374fla4veaIHy+gA+qRRuug==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4750,7 +4750,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-package-json@0.65.0(@types/estree@1.0.8)(eslint@9.39.1(jiti@2.6.1))(jsonc-eslint-parser@2.4.0):
+  eslint-plugin-package-json@0.85.0(@types/estree@1.0.8)(eslint@9.39.1(jiti@2.6.1))(jsonc-eslint-parser@2.4.0):
     dependencies:
       '@altano/repository-tools': 2.0.1
       change-case: 5.4.4
@@ -4759,7 +4759,7 @@ snapshots:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-fix-utils: 0.4.0(@types/estree@1.0.8)(eslint@9.39.1(jiti@2.6.1))
       jsonc-eslint-parser: 2.4.0
-      package-json-validator: 0.34.0
+      package-json-validator: 0.59.0
       semver: 7.7.3
       sort-object-keys: 2.0.0
       sort-package-json: 3.4.0
@@ -5777,10 +5777,11 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.34.0:
+  package-json-validator@0.59.0:
     dependencies:
       semver: 7.7.3
       validate-npm-package-license: 3.0.4
+      validate-npm-package-name: 7.0.0
       yargs: 18.0.0
 
   parent-module@1.0.1:

--- a/src/formats.ts
+++ b/src/formats.ts
@@ -1,4 +1,4 @@
 export const emailFormat = /\S+@\S+/; // I know this isn't thorough. it's not supposed to be.
-export const packageFormat = /^[a-z0-9@/][\w@/.\-]*$/i;
+export const packageFormat = /^[a-z0-9@/][\w@/.-]*$/i;
 export const urlFormat = /^https?:\/\/[a-z.\-0-9]+/;
-export const versionFormat = /^\d+\.\d[0-9+a-z.\-]+$/i;
+export const versionFormat = /^\d+\.\d[0-9+a-z.-]+$/i;

--- a/src/utils/validatePeople.ts
+++ b/src/utils/validatePeople.ts
@@ -13,6 +13,7 @@ export const isPerson = (obj: unknown): obj is Person => {
 function validatePerson(obj: Person | string): Result {
 	let result = new Result();
 	if (typeof obj == "string") {
+		// eslint-disable-next-line regexp/no-super-linear-backtracking, regexp/no-unused-capturing-group
 		const authorRegex = /^([^<(\s][^<(]*)?(\s*<(.*?)>)?(\s*\((.*?)\))?/;
 		const authorFields = authorRegex.exec(obj);
 		if (authorFields) {
@@ -32,7 +33,7 @@ function validatePerson(obj: Person | string): Result {
 		if (typeof obj.name === "undefined") {
 			result.addIssue("person should have a name");
 		}
-		const entries = Object.entries(obj);
+		const entries = Object.entries(obj) as [string, string][];
 		for (let i = 0; i < entries.length; i++) {
 			const [key, value] = entries[i];
 			const childResult = new ChildResult(i);

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,11 +1,7 @@
 import type { SpecMap, SpecName } from "./Spec.types.ts";
 
 import { packageFormat, urlFormat, versionFormat } from "./formats.ts";
-import {
-	validateFieldType,
-	validatePeople,
-	validateUrlTypes,
-} from "./utils/index.js";
+import { validateFieldType, validateUrlTypes } from "./utils/index.js";
 import {
 	validateAuthor,
 	validateBin,
@@ -144,7 +140,7 @@ const getSpecMap = (
 			contributors: {
 				required: true,
 				type: "array",
-				validate: (_, value) => validatePeople(value).errorMessages,
+				validate: (_, value) => validateContributors(value).errorMessages,
 			},
 			cpu: { type: "array" },
 			dependencies: {
@@ -166,7 +162,7 @@ const getSpecMap = (
 			maintainers: {
 				required: true,
 				type: "array",
-				validate: (_, value) => validatePeople(value).errorMessages,
+				validate: (_, value) => validateContributors(value).errorMessages,
 			},
 			name: { format: packageFormat, required: true, type: "string" },
 			os: { type: "array" },
@@ -191,7 +187,7 @@ const getSpecMap = (
 			checksums: { type: "object" },
 			contributors: {
 				type: "array",
-				validate: (_, value) => validatePeople(value).errorMessages,
+				validate: (_, value) => validateContributors(value).errorMessages,
 			},
 
 			cpu: { type: "array" },
@@ -212,7 +208,7 @@ const getSpecMap = (
 			main: { required: true, type: "string" },
 			maintainers: {
 				type: "array",
-				validate: (_, value) => validatePeople(value).errorMessages,
+				validate: (_, value) => validateContributors(value).errorMessages,
 				warning: true,
 			},
 			name: { format: packageFormat, required: true, type: "string" },
@@ -235,6 +231,7 @@ const parse = (data: string) => {
 	}
 	let parsed;
 	try {
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 		parsed = JSON.parse(data);
 	} catch (e: unknown) {
 		let errorMessage = "Invalid JSON";
@@ -252,6 +249,7 @@ const parse = (data: string) => {
 		return `Invalid JSON - not an object (actual type: ${typeof parsed})`;
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
 	return parsed;
 };
 
@@ -296,6 +294,7 @@ export const validate: ValidateFunction = (
 	specNameOrOptions: SpecName | ValidationOptions = "npm",
 	options: ValidationOptions = {},
 ): ValidationOutput => {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const parsed = typeof data == "object" ? data : parse(data);
 	const out: ValidationOutput = { valid: false };
 
@@ -312,7 +311,10 @@ export const validate: ValidateFunction = (
 		specName = specNameOrOptions;
 	}
 
-	const map = getSpecMap(parsed.private, specName);
+	const map = getSpecMap(
+		(parsed.private as boolean | undefined) ?? false,
+		specName,
+	);
 	if (map === false) {
 		out.critical = { "Invalid specification": specName };
 		return out;
@@ -347,6 +349,7 @@ export const validate: ValidateFunction = (
 
 		// Type checking
 		if (field.types || field.type) {
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 			const typeErrors = validateFieldType(name, field, parsed[name]);
 			if (typeErrors.length > 0) {
 				errors.push(...typeErrors.map((e) => ({ field: name, message: e })));
@@ -355,6 +358,7 @@ export const validate: ValidateFunction = (
 		}
 
 		// Regexp format check
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 		if (field.format && !field.format.test(parsed[name])) {
 			errors.push({
 				field: name,

--- a/src/validators/validateBundleDependencies.ts
+++ b/src/validators/validateBundleDependencies.ts
@@ -15,7 +15,7 @@ export const validateBundleDependencies = (obj: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;
 				childResult.addIssue(

--- a/src/validators/validateContributors.test.ts
+++ b/src/validators/validateContributors.test.ts
@@ -64,7 +64,7 @@ describe(validateContributors, () => {
 		expect(result.issues).toHaveLength(0);
 		expect(result.childResults).toHaveLength(2);
 		expect(result.errorMessages).toEqual([
-			"item 1 is invalid; it should be a person object with at least a \`name\`",
+			"item 1 is invalid; it should be a person object with at least a `name`",
 		]);
 		expect(mockValidatePeople).toHaveBeenCalledTimes(1);
 	});

--- a/src/validators/validateContributors.ts
+++ b/src/validators/validateContributors.ts
@@ -19,7 +19,7 @@ export const validateContributors = (obj: unknown): Result => {
 	if (Array.isArray(obj)) {
 		for (let i = 0; i < obj.length; i++) {
 			let childResult: Result;
-			const item = obj[i];
+			const item: unknown = obj[i];
 			if (!isPerson(item)) {
 				childResult = new Result([
 					`item ${i} is invalid; it should be a person object with at least a \`name\``,

--- a/src/validators/validateCpu.ts
+++ b/src/validators/validateCpu.ts
@@ -27,7 +27,7 @@ export const validateCpu = (obj: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -64,7 +64,7 @@ export const validateDependencies = (value: unknown): Result => {
 		const entries = Object.entries(value);
 		for (let i = 0; i < entries.length; ++i) {
 			const childResult = new ChildResult(i);
-			const [pkg, version] = entries[i];
+			const [pkg, version] = entries[i] as [string, unknown];
 			if (
 				!packageFormat.test(pkg) &&
 				!(typeof version === "string" && isUnpublishedVersion(version))

--- a/src/validators/validateDirectories.ts
+++ b/src/validators/validateDirectories.ts
@@ -11,7 +11,7 @@ export const validateDirectories = (obj: unknown): Result => {
 		const entries = Object.entries(obj);
 		for (let i = 0; i < entries.length; i++) {
 			const childResult = new ChildResult(i);
-			const [key, value] = entries[i];
+			const [key, value] = entries[i] as [string, unknown];
 
 			const normalizedKey = key.trim();
 			const propertyName =

--- a/src/validators/validateExports.ts
+++ b/src/validators/validateExports.ts
@@ -30,7 +30,7 @@ const validateExportCondition = (
 	else if (obj && typeof obj === "object" && !Array.isArray(obj)) {
 		const entries = Object.entries(obj);
 		for (let i = 0; i < entries.length; i++) {
-			const [key, value] = entries[i];
+			const [key, value] = entries[i] as [string, unknown];
 
 			// Recurse to add results from children.
 			const childResult = validateExportCondition(value, key, i);

--- a/src/validators/validateFiles.ts
+++ b/src/validators/validateFiles.ts
@@ -14,7 +14,7 @@ export const validateFiles = (obj: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;

--- a/src/validators/validateKeywords.ts
+++ b/src/validators/validateKeywords.ts
@@ -13,7 +13,7 @@ export const validateKeywords = (obj: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;

--- a/src/validators/validateMan.ts
+++ b/src/validators/validateMan.ts
@@ -36,7 +36,7 @@ export const validateMan = (obj: unknown): Result => {
 		// If it's an array, check if all items are valid strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;
 				childResult.addIssue(

--- a/src/validators/validateOs.ts
+++ b/src/validators/validateOs.ts
@@ -24,7 +24,7 @@ export const validateOs = (obj: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < obj.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = obj[i];
+			const item: unknown = obj[i];
 
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;

--- a/src/validators/validatePublishConfig.ts
+++ b/src/validators/validatePublishConfig.ts
@@ -91,7 +91,7 @@ export const validatePublishConfig = (value: unknown): Result => {
 		// Validate specific properties
 		const entries = Object.entries(value);
 		for (let i = 0; i < entries.length; i++) {
-			const [key, value] = entries[i];
+			const [key, value] = entries[i] as [string, unknown];
 			let childResult: Result;
 			if (key in propertyValidators) {
 				childResult = propertyValidators[key](value);

--- a/src/validators/validateScripts.ts
+++ b/src/validators/validateScripts.ts
@@ -12,7 +12,7 @@ export const validateScripts = (obj: unknown): Result => {
 		for (let i = 0; i < entries.length; i++) {
 			const childResult = new ChildResult(i);
 
-			const [key, value] = entries[i];
+			const [key, value] = entries[i] as [string, unknown];
 			const normalizedKey = key.trim();
 			const propertyName =
 				normalizedKey === "" ? String(i) : `"${normalizedKey}"`;

--- a/src/validators/validateSideEffects.ts
+++ b/src/validators/validateSideEffects.ts
@@ -14,7 +14,7 @@ export const validateSideEffects = (value: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < value.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = value[i];
+			const item: unknown = value[i];
 			if (typeof item !== "string") {
 				const itemType = item === null ? "null" : typeof item;
 				childResult.addIssue(

--- a/src/validators/validateWorkspaces.ts
+++ b/src/validators/validateWorkspaces.ts
@@ -14,7 +14,7 @@ export const validateWorkspaces = (value: unknown): Result => {
 		// If it's an array, check if all items are non-empty strings
 		for (let i = 0; i < value.length; i++) {
 			const childResult = new ChildResult(i);
-			const item = value[i];
+			const item: unknown = value[i];
 
 			if (typeof item !== "string") {
 				const itemType =


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change follows the guidance from the eslint team to add `files` to all config objects in our eslint.config (except global ignores and settings).

I also updated the `eslint-plugin-package-json` and adopted the `recommended-publishable` config
