### PR TITLE
feat!: remove support for the legacy commonjs package specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,9 +815,69 @@ const packageData = {
 const result = validateType(packageData.type);
 ```
 
+### validateVersion(value)
+
+This function validates the value of the `version` property of a `package.json`.
+It takes the value, and validates it using `semver`, which is the same package that npm uses.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateVersion } from "package-json-validator";
+
+const packageData = {
+	version: "1.2.3",
+};
+
+const result = validateVersion(packageData.version);
+```
+
+### validateWorkspaces(value)
+
+This function validates the value of the `workspaces` property of a `package.json`.
+It takes the value, and validates it against the following criteria.
+
+- the property is an array
+- all items in the array should be non-empty strings
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateWorkspaces } from "package-json-validator";
+
+const packageData = {
+	workspaces: ["./app", "./packages/*"],
+};
+
+const result = validateWorkspaces(packageData.cpu);
+```
+
 ## Specification
 
 This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.
+
+## Deprecation Policy
+
+We never _want_ to remove things, when we're building them!
+But the reality is that libraries evolve and deprecations are a fact of life.
+Following are the different timeframes that we've defined as it relates to deprecating APIs in this project.
+
+### RFC Timeframe (6 weeks)
+
+When some aspect of our API is going to be deprecated (and eventually removed), it must initially go through an RFC phase.
+Whoever's motivating the removal of the api, should create an RFC issue explaining the proposal and inviting feedback from the community.
+That RFC should remain active for at least 6 weeks.
+The RFC text should make clear what the target date is for closing the RFC.
+Once the RFC period is over, if the removal is still moving forward, the API(s) should be officially deprecated.
+
+### Removal Timeframe (6 months)
+
+Once an API has been marked as deprecated, it will remain intact for at least 6 months.
+After 6 months from the date of deprecation, the API is subject to removal.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -815,69 +815,9 @@ const packageData = {
 const result = validateType(packageData.type);
 ```
 
-### validateVersion(value)
-
-This function validates the value of the `version` property of a `package.json`.
-It takes the value, and validates it using `semver`, which is the same package that npm uses.
-
-It returns a `Result` object (See [Result Types](#result-types)).
-
-#### Examples
-
-```ts
-import { validateVersion } from "package-json-validator";
-
-const packageData = {
-	version: "1.2.3",
-};
-
-const result = validateVersion(packageData.version);
-```
-
-### validateWorkspaces(value)
-
-This function validates the value of the `workspaces` property of a `package.json`.
-It takes the value, and validates it against the following criteria.
-
-- the property is an array
-- all items in the array should be non-empty strings
-
-It returns a `Result` object (See [Result Types](#result-types)).
-
-#### Examples
-
-```ts
-import { validateWorkspaces } from "package-json-validator";
-
-const packageData = {
-	workspaces: ["./app", "./packages/*"],
-};
-
-const result = validateWorkspaces(packageData.cpu);
-```
-
 ## Specification
 
 This package uses the `npm` [spec](https://docs.npmjs.com/cli/configuring-npm/package-json) along with additional [supporting documentation from node](https://nodejs.org/api/packages.html), as its source of truth for validation.
-
-## Deprecation Policy
-
-We never _want_ to remove things, when we're building them!
-But the reality is that libraries evolve and deprecations are a fact of life.
-Following are the different timeframes that we've defined as it relates to deprecating APIs in this project.
-
-### RFC Timeframe (6 weeks)
-
-When some aspect of our API is going to be deprecated (and eventually removed), it must initially go through an RFC phase.
-Whoever's motivating the removal of the api, should create an RFC issue explaining the proposal and inviting feedback from the community.
-That RFC should remain active for at least 6 weeks.
-The RFC text should make clear what the target date is for closing the RFC.
-Once the RFC period is over, if the removal is still moving forward, the API(s) should be officially deprecated.
-
-### Removal Timeframe (6 months)
-
-Once an API has been marked as deprecated, it will remain intact for at least 6 months.
-After 6 months from the date of deprecation, the API is subject to removal.
 
 ## Development
 

--- a/src/Spec.types.ts
+++ b/src/Spec.types.ts
@@ -2,9 +2,6 @@ export type FieldSpec = FieldSpecWithType | FieldSpecWithTypes;
 
 export type SpecMap = Record<string, FieldSpec>;
 
-/** @deprecated commonjs_1.0 and commonjs_1.1 specs have been deprecated */
-export type SpecName = "commonjs_1.0" | "commonjs_1.1" | "npm";
-
 export type SpecType = "array" | "boolean" | "object" | "string";
 
 interface BaseFieldSpec {

--- a/src/bin/pjv.ts
+++ b/src/bin/pjv.ts
@@ -9,15 +9,12 @@ import fs from "node:fs";
 import process from "node:process";
 import yargs from "yargs";
 
-import type { SpecName } from "../Spec.types.ts";
-
 import { validate } from "../validate.ts";
 
 interface Options {
 	filename: string;
 	quiet: boolean;
 	recommendations: boolean;
-	spec: SpecName;
 	warnings: boolean;
 }
 
@@ -27,13 +24,6 @@ const options = yargs(process.argv.slice(2))
 		alias: "f",
 		default: "package.json",
 		description: "package.json file to validate",
-	})
-	.options("spec", {
-		alias: "s",
-		choices: ["npm", "commonjs_1.0", "commonjs_1.1"],
-		default: "npm",
-		deprecated: true,
-		description: "spec to use - npm|commonjs_1.0|commonjs_1.1",
 	})
 	.options("warnings", {
 		alias: "w",
@@ -67,7 +57,7 @@ if (!fs.existsSync(options.filename)) {
 	process.exitCode = 1;
 } else {
 	const contents = fs.readFileSync(options.filename).toString(),
-		results = validate(contents, options.spec, {
+		results = validate(contents, {
 			recommendations: options.recommendations,
 			warnings: options.warnings,
 		});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export type { Result } from "./Result.ts";
-export type { SpecName, SpecType } from "./Spec.types.ts";
 export { validate } from "./validate.ts";
 export {
 	validateAuthor,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -33,96 +33,94 @@ import {
 } from "./validators/index.ts";
 
 // https://docs.npmjs.com/cli/v11/configuring-npm/package-json
-		// https://nodejs.org/api/packages.html
-const getSpecMap = (
-	isPrivate: boolean,
-): SpecMap => ({
-			author: {
-				validate: (_, value) => validateAuthor(value).errorMessages,
-				warning: true,
-			},
-			bin: { validate: (_, value) => validateBin(value).errorMessages },
-			bugs: { validate: validateUrlOrMailto, warning: true },
-			bundledDependencies: {
-				validate: (_, value) => validateBundleDependencies(value).errorMessages,
-			},
-			bundleDependencies: {
-				validate: (_, value) => validateBundleDependencies(value).errorMessages,
-			},
-			config: { validate: (_, value) => validateConfig(value).errorMessages },
-			contributors: {
-				validate: (_, value) => validateContributors(value).errorMessages,
-			},
-			cpu: { validate: (_, value) => validateCpu(value).errorMessages },
-			dependencies: {
-				recommended: true,
-				validate: (_, value) => validateDependencies(value).errorMessages,
-			},
-			description: {
-				validate: (_, value) => validateDescription(value).errorMessages,
-				warning: true,
-			},
-			devDependencies: {
-				validate: (_, value) => validateDependencies(value).errorMessages,
-			},
-			directories: {
-				validate: (_, value) => validateDirectories(value).errorMessages,
-			},
-			engines: {
-				recommended: true,
-				validate: (_, value) => validateEngines(value).errorMessages,
-			},
-			exports: { validate: (_, value) => validateExports(value).errorMessages },
-			files: { validate: (_, value) => validateFiles(value).errorMessages },
-			homepage: {
-				recommended: true,
-				validate: (_, value) => validateHomepage(value).errorMessages,
-			},
-			keywords: {
-				validate: (_, value) => validateKeywords(value).errorMessages,
-				warning: true,
-			},
-			license: {
-				validate: (_, value) => validateLicense(value).errorMessages,
-				warning: true,
-			},
-			main: { validate: (_, value) => validateMain(value).errorMessages },
-			man: { validate: (_, value) => validateMan(value).errorMessages },
-			name: {
-				required: !isPrivate,
-				validate: (_, value) => validateName(value).errorMessages,
-			},
-			optionalDependencies: {
-				validate: (_, value) => validateDependencies(value).errorMessages,
-			},
-			os: { validate: (_, value) => validateOs(value).errorMessages },
-			peerDependencies: {
-				validate: (_, value) => validateDependencies(value).errorMessages,
-			},
-			private: { validate: (_, value) => validatePrivate(value).errorMessages },
-			publishConfig: {
-				validate: (_, value) => validatePublishConfig(value).errorMessages,
-			},
-			repository: {
-				validate: (_, value) => validateRepository(value).errorMessages,
-				warning: true,
-			},
-			scripts: { validate: (_, value) => validateScripts(value).errorMessages },
-			sideEffects: {
-				validate: (_, value) => validateSideEffects(value).errorMessages,
-			},
-			type: {
-				recommended: true,
-				validate: (_, value) => validateType(value).errorMessages,
-			},
-			version: {
-				required: !isPrivate,
-				validate: (_, value) => validateVersion(value).errorMessages,
-			},
-			workspaces: {
-				validate: (_, value) => validateWorkspaces(value).errorMessages,
-			},
-		});
+// https://nodejs.org/api/packages.html
+const getSpecMap = (isPrivate: boolean): SpecMap => ({
+	author: {
+		validate: (_, value) => validateAuthor(value).errorMessages,
+		warning: true,
+	},
+	bin: { validate: (_, value) => validateBin(value).errorMessages },
+	bugs: { validate: validateUrlOrMailto, warning: true },
+	bundledDependencies: {
+		validate: (_, value) => validateBundleDependencies(value).errorMessages,
+	},
+	bundleDependencies: {
+		validate: (_, value) => validateBundleDependencies(value).errorMessages,
+	},
+	config: { validate: (_, value) => validateConfig(value).errorMessages },
+	contributors: {
+		validate: (_, value) => validateContributors(value).errorMessages,
+	},
+	cpu: { validate: (_, value) => validateCpu(value).errorMessages },
+	dependencies: {
+		recommended: true,
+		validate: (_, value) => validateDependencies(value).errorMessages,
+	},
+	description: {
+		validate: (_, value) => validateDescription(value).errorMessages,
+		warning: true,
+	},
+	devDependencies: {
+		validate: (_, value) => validateDependencies(value).errorMessages,
+	},
+	directories: {
+		validate: (_, value) => validateDirectories(value).errorMessages,
+	},
+	engines: {
+		recommended: true,
+		validate: (_, value) => validateEngines(value).errorMessages,
+	},
+	exports: { validate: (_, value) => validateExports(value).errorMessages },
+	files: { validate: (_, value) => validateFiles(value).errorMessages },
+	homepage: {
+		recommended: true,
+		validate: (_, value) => validateHomepage(value).errorMessages,
+	},
+	keywords: {
+		validate: (_, value) => validateKeywords(value).errorMessages,
+		warning: true,
+	},
+	license: {
+		validate: (_, value) => validateLicense(value).errorMessages,
+		warning: true,
+	},
+	main: { validate: (_, value) => validateMain(value).errorMessages },
+	man: { validate: (_, value) => validateMan(value).errorMessages },
+	name: {
+		required: !isPrivate,
+		validate: (_, value) => validateName(value).errorMessages,
+	},
+	optionalDependencies: {
+		validate: (_, value) => validateDependencies(value).errorMessages,
+	},
+	os: { validate: (_, value) => validateOs(value).errorMessages },
+	peerDependencies: {
+		validate: (_, value) => validateDependencies(value).errorMessages,
+	},
+	private: { validate: (_, value) => validatePrivate(value).errorMessages },
+	publishConfig: {
+		validate: (_, value) => validatePublishConfig(value).errorMessages,
+	},
+	repository: {
+		validate: (_, value) => validateRepository(value).errorMessages,
+		warning: true,
+	},
+	scripts: { validate: (_, value) => validateScripts(value).errorMessages },
+	sideEffects: {
+		validate: (_, value) => validateSideEffects(value).errorMessages,
+	},
+	type: {
+		recommended: true,
+		validate: (_, value) => validateType(value).errorMessages,
+	},
+	version: {
+		required: !isPrivate,
+		validate: (_, value) => validateVersion(value).errorMessages,
+	},
+	workspaces: {
+		validate: (_, value) => validateWorkspaces(value).errorMessages,
+	},
+});
 
 const parse = (data: string) => {
 	if (typeof data != "string") {
@@ -153,7 +151,10 @@ const parse = (data: string) => {
 	return parsed;
 };
 
-export type ValidateFunction = (data: object | string, options?: ValidationOptions) => ValidationOutput;
+export type ValidateFunction = (
+	data: object | string,
+	options?: ValidationOptions,
+) => ValidationOutput;
 
 export interface ValidationOptions {
 	recommendations?: boolean;


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #314
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes support for the long-outdated commonjs 1.0 and 1.1 spec, unifying around the npm spec.

BEGIN_COMMIT_OVERRIDE
feat!: remove support for the legacy commonjs package specs (#608)
END_COMMIT_OVERRIDE
