### PR TITLE
chore: add dependency security setting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -136,6 +136,10 @@ export default defineConfig(
 		files: ["pnpm-workspace.yaml"],
 		rules: {
 			"yml/file-extension": "off",
+			"yml/sort-keys": [
+				"error",
+				{ order: { type: "asc" }, pathPattern: "^.*$" },
+			],
 		},
 	},
 	{

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,12 @@ export default defineConfig(
 		},
 	},
 	{
+		files: ["pnpm-workspace.yaml"],
+		rules: {
+			"yml/file-extension": "off",
+		},
+	},
+	{
 		files: ["./eslint.config.js", "./**/*.test.*"],
 		rules: {
 			"n/no-unsupported-features/node-builtins": "off",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAge: 1440
+trustPolicy: no-downgrade


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change enables two new(er) pnpm security-oriented settings to our config.  Minimum Release Age, prevents dependencies (direct or otherwise) that are newer than a particular age from being installed (the idea being that any significant supply chain exploits will have been discovered and resolved in that time).  Trust Policy, prevents dependencies from being installed that have regressed in terms of their publishing security since the previous release.

- https://pnpm.io/settings#minimumreleaseage
- https://pnpm.io/settings#trustpolicy
