### PR TITLE
ci: add token to release-please action

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,10 +1,3 @@
-jobs:
-  accessibility_alt_text_bot:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: github/accessibility-alt-text-bot@9b4b0e03eefd10cfafc676d9b67068ec30b68e90 # v1.7.0
-
 name: Accessibility Alt Text Bot
 
 on:
@@ -24,3 +17,10 @@ on:
 permissions:
   issues: write
   pull-requests: write
+
+jobs:
+  accessibility_alt_text_bot:
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/accessibility-alt-text-bot@9b4b0e03eefd10cfafc676d9b67068ec30b68e90 # v1.7.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,11 @@
+name: CI
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     name: Build
@@ -47,11 +55,3 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
       - uses: ./.github/actions/prepare
       - run: pnpm typecheck
-
-name: CI
-
-on:
-  pull_request: ~
-  push:
-    branches:
-      - main

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,3 +1,10 @@
+name: Contributors
+
+on:
+  push:
+    branches:
+      - main
+
 jobs:
   contributors:
     runs-on: ubuntu-latest
@@ -9,10 +16,3 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         uses: JoshuaKGoldberg/all-contributors-auto-action@944abe4387e751b5bbb38616cb25cf4a4ca998f2 # v0.5.0
-
-name: Contributors
-
-on:
-  push:
-    branches:
-      - main

--- a/.github/workflows/octoguide.yml
+++ b/.github/workflows/octoguide.yml
@@ -1,13 +1,3 @@
-jobs:
-  octoguide:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JoshuaKGoldberg/octoguide@879a317d50109c6446513149b381feb568364a89 # 0.18.0
-        with:
-          config: strict
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
 name: OctoGuide
 
 on:
@@ -43,3 +33,13 @@ permissions:
   discussions: write
   issues: write
   pull-requests: write
+
+jobs:
+  octoguide:
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JoshuaKGoldberg/octoguide@879a317d50109c6446513149b381feb568364a89 # 0.18.0
+        with:
+          config: strict
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,3 +1,14 @@
+name: Post Release
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   post_release:
     runs-on: ubuntu-latest
@@ -18,14 +29,3 @@ jobs:
             * [npm package (@latest dist-tag)](https://www.npmjs.com/package/package-json-validator/v/${{ env.npm_version }})
 
             Cheers! 📦🚀
-
-name: Post Release
-
-on:
-  release:
-    types:
-      - published
-
-permissions:
-  issues: write
-  pull-requests: write

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -1,3 +1,13 @@
+name: PR Review Requested
+
+on:
+  pull_request_target:
+    types:
+      - review_requested
+
+permissions:
+  pull-requests: write
+
 jobs:
   pr_review_requested:
     runs-on: ubuntu-latest
@@ -9,13 +19,3 @@ jobs:
         run: |
           echo "Don't worry if the previous step failed."
           echo "See https://github.com/actions-ecosystem/action-remove-labels/issues/221."
-
-name: PR Review Requested
-
-on:
-  pull_request_target:
-    types:
-      - review_requested
-
-permissions:
-  pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         if: ${{ steps.release.outputs.release_created }}
       - uses: ./.github/actions/prepare


### PR DESCRIPTION

<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds the same `ACCESS_TOKEN` that we're using for the Contributors workflow to the release-please action, so that downstream workflows will kick off properly.
