### PR TITLE
ci: exclude release PRs from octoguide

### DIFF
--- a/.github/workflows/octoguide.yml
+++ b/.github/workflows/octoguide.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   octoguide:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: ${{ !endsWith(github.actor, '[bot]') && !contains(github.event.pull_request.labels.*.name, 'autorelease') }}
     runs-on: ubuntu-latest
     steps:
       - uses: JoshuaKGoldberg/octoguide@879a317d50109c6446513149b381feb568364a89 # 0.18.0


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Coming from https://github.com/JoshuaKGoldberg/package-json-validator/pull/623#issuecomment-3704102462, this change adds a condition to the octoguide workflow to prevent running on PRs labeled by release-please.  I'm not _super_ confident about this condition, and I'm not terribly familiar with octoguide, so if you think there's a better way to achieve this, I'm open to it.
