### PR TITLE
ci: add support for releasing prerelease versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,40 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
+
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         if: ${{ steps.release.outputs.release_created }}
+
       - uses: ./.github/actions/prepare
         if: ${{ steps.release.outputs.release_created }}
-      - run: |
-          pnpm build
-          pnpm publish
+
+      - name: Determine dist-tag
+        id: determine_dist_tag
         if: ${{ steps.release.outputs.release_created }}
+        run: |
+          TAG_NAME="${{ steps.release.outputs.tag_name }}"
+          echo "Release tag: $TAG_NAME"
+
+          if [[ "$TAG_NAME" == *"-alpha."* ]]; then
+            DIST_TAG=alpha
+          elif [[ "$TAG_NAME" == *"-beta."* ]]; then
+            DIST_TAG=beta
+          elif [[ "$TAG_NAME" == *"-rc."* ]]; then
+            DIST_TAG=rc
+          elif [[ "$TAG_NAME" == *"-"* ]]; then
+            DIST_TAG=next
+          else
+            DIST_TAG=latest
+          fi
+
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Build and Publish
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          pnpm build
+          echo "Publishing to npm with dist-tag '${{ steps.determine_dist_tag.outputs.dist_tag }}'"
+          pnpm publish --tag ${{ steps.determine_dist_tag.outputs.dist_tag }}
 
   post_release:
     needs: release_please


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds logic to the release workflow to add the appropriate `dist-tag` to the `publish` command, when a release is for a prerelease version.
