### PR TITLE
ci: add publish-branch to publish command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           pnpm build
           echo "Publishing to npm with dist-tag '${{ steps.determine_dist_tag.outputs.dist_tag }}'"
-          pnpm publish --tag ${{ steps.determine_dist_tag.outputs.dist_tag }}
+          pnpm publish --publish-branch ${{ github.ref_name }} --tag ${{ steps.determine_dist_tag.outputs.dist_tag }}
 
   post_release:
     needs: release_please


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change add the `--publish-branch` option to the `pnpm publish` command.  Without that, pnpm will only publish from `main`.

Release-As: 1.0.0-beta.1
