### PR TITLE
ci: add workaround for prerelease bug

### DIFF
--- a/.github/release-please/release-please-config.beta.json
+++ b/.github/release-please/release-please-config.beta.json
@@ -16,5 +16,6 @@
 	"release-type": "node",
 	"packages": {
 		".": {}
-	}
+	},
+	"versioning": "prerelease"
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a `versioning` field to the `beta` branch release config, as recommended by https://github.com/googleapis/release-please/issues/2641#issuecomment-3697495726 as a workaround for it bumping pre-release versions incorrectly.  (1.0.0-beta.0 -> 2.0.0-beta.0 https://github.com/JoshuaKGoldberg/package-json-validator/pull/670)
