### PR TITLE
ci: add dynamic dist-tag to release comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: write
       id-token: write # Required for OIDC
     outputs:
+      dist_tag: ${{ steps.determine_dist_tag.outputs.dist_tag }}
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
@@ -81,6 +82,6 @@ jobs:
             The release is available on:
 
             * [GitHub releases](https://github.com/JoshuaKGoldberg/package-json-validator/releases/tag/{release_tag})
-            * [npm package (@latest dist-tag)](https://www.npmjs.com/package/package-json-validator/v/${{ env.npm_version }})
+            * [npm package (@${{ needs.release_please.outputs.dist_tag }} dist-tag)](https://www.npmjs.com/package/package-json-validator/v/${{ env.npm_version }})
 
             Cheers! 📦🚀


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I noticed the dist-tag referenced on the link in the release comments was hard-coded to `latest`, which isn't accurate now that we're publishing to other `dist-tag`s.  This makes that text dynamic, based on what we published to in the release_please job.

<img width="260" height="73" alt="screenshot of comment" src="https://github.com/user-attachments/assets/e426ff14-b9b4-4760-85cc-9f1156478495" />
