### PR TITLE
ci: remove sentences-per-line

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
 		"prettier": "3.8.0",
 		"prettier-plugin-curly": "0.4.0",
 		"prettier-plugin-packagejson": "2.5.19",
-		"prettier-plugin-sentences-per-line": "0.2.0",
 		"prettier-plugin-sh": "0.18.0",
 		"tsdown": "0.19.0",
 		"typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       prettier-plugin-packagejson:
         specifier: 2.5.19
         version: 2.5.19(prettier@3.8.0)
-      prettier-plugin-sentences-per-line:
-        specifier: 0.2.0
-        version: 0.2.0(prettier@3.8.0)
       prettier-plugin-sh:
         specifier: 0.18.0
         version: 0.18.0(prettier@3.8.0)
@@ -1929,11 +1926,6 @@ packages:
       prettier:
         optional: true
 
-  prettier-plugin-sentences-per-line@0.2.0:
-    resolution: {integrity: sha512-c9JzBEcpOHVvpFojb7MAgUqhJ59k5v92J6k+7+GI79JTrooV507vwmINn2JviUixU0U0NWZjwp4/KWBnfgge0w==}
-    peerDependencies:
-      prettier: ^3
-
   prettier-plugin-sh@0.18.0:
     resolution: {integrity: sha512-cW1XL27FOJQ/qGHOW6IHwdCiNWQsAgK+feA8V6+xUTaH0cD3Mh+tFAtBvEEWvuY6hTDzRV943Fzeii+qMOh7nQ==}
     engines: {node: '>=16.0.0'}
@@ -2030,10 +2022,6 @@ packages:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
     engines: {node: '>=10'}
     hasBin: true
-
-  sentences-per-line@0.5.0:
-    resolution: {integrity: sha512-XWvVvZJksvzYJaEWybIjdStXZdi8ZfGzPtvbvmiOaX9Be2zB4zw+55Q1ame/FRno8x/KDsC5iXX+1NOCz/CjHg==}
-    engines: {node: '>=22.14.0'}
 
   sh-syntax@0.5.8:
     resolution: {integrity: sha512-JfVoxf4FxQI5qpsPbkHhZo+n6N9YMJobyl4oGEUBb/31oQYlgTjkXQD8PBiafS2UbWoxrTO0Z5PJUBXEPAG1Zw==}
@@ -4231,11 +4219,6 @@ snapshots:
     optionalDependencies:
       prettier: 3.8.0
 
-  prettier-plugin-sentences-per-line@0.2.0(prettier@3.8.0):
-    dependencies:
-      prettier: 3.8.0
-      sentences-per-line: 0.5.0
-
   prettier-plugin-sh@0.18.0(prettier@3.8.0):
     dependencies:
       '@reteps/dockerfmt': 0.3.6
@@ -4367,8 +4350,6 @@ snapshots:
       regexp-ast-analysis: 0.7.1
 
   semver@7.7.3: {}
-
-  sentences-per-line@0.5.0: {}
 
   sh-syntax@0.5.8:
     dependencies:

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -7,7 +7,6 @@ const config = {
 	plugins: [
 		"prettier-plugin-curly",
 		"prettier-plugin-packagejson",
-		"prettier-plugin-sentences-per-line",
 		"prettier-plugin-sh",
 	],
 	useTabs: true,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
This change removes the sentences-per-line plugin, which has been blocking renovate updates for weeks.  Once the trusted publishing issues are resolved, we can re-introduce it.
