### PR TITLE
fix: remove 1.0.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [1.0.0](https://github.com/JoshuaKGoldberg/package-json-validator/compare/v1.0.0-rc.0...v1.0.0) (2026-02-22)
-
-
-* trigger 1.0.0 release ([#716](https://github.com/JoshuaKGoldberg/package-json-validator/issues/716)) ([2dc6f7b](https://github.com/JoshuaKGoldberg/package-json-validator/commit/2dc6f7b601233a34be94a8c1d3e8e05573b15808))
-
 ## [1.0.0-rc.0](https://github.com/JoshuaKGoldberg/package-json-validator/compare/v1.0.0-beta.1...v1.0.0-rc.0) (2026-02-17)
 
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

v1.0.0 was accidentally published last year, and even though Josh removed it at that point, npm won't let us publish that version.  So, this is to trigger a patch release so we can publish 1.0.1.
