### PR TITLE
feat: add option to `validate` to return new type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The index of this property in relation to its parent's collection (properties or
 
 The message with information about this issue.
 
-## API
+## Functions
 
 ### validate(data, options?)
 
@@ -143,28 +143,88 @@ const text = JSON.stringify({
 });
 
 const data = validate(text);
+
+console.log(data);
+
+// {
+//   valid: true,
+//   warnings: [
+//     'Missing recommended field: description',
+//     'Missing recommended field: keywords',
+//     'Missing recommended field: bugs',
+//     'Missing recommended field: licenses',
+//     'Missing recommended field: author',
+//     'Missing recommended field: contributors',
+//     'Missing recommended field: repository'
+//   ],
+//   recommendations: [
+//     'Missing optional field: homepage',
+//     'Missing optional field: engines'
+//   ]
+// }
 ```
 
-Output for above example:
+#### New Return Type (>= 1.4.0)
 
-```js
-console.log(data);
-// {
-//  valid: true,
-//   warnings: [
-//    'Missing recommended field: description',
-//    'Missing recommended field: keywords',
-//    'Missing recommended field: bugs',
-//    'Missing recommended field: licenses',
-//    'Missing recommended field: author',
-//    'Missing recommended field: contributors',
-//    'Missing recommended field: repository'
-//  ],
-//  recommendations: [
-//    'Missing optional field: homepage',
-//    'Missing optional field: engines'
-//  ]
-// }
+Starting in v1.4, you can opt-in to the new `Result` return type for `validate`.
+This has been the return type for all of the more granular `validate*` functions for a while now, and gives more specific information about which parts of the `package.json` are failing validation.
+See [Result Types](#result-types) for more details about this construct.
+
+If you'd like to opt-in to the new behavior before it becomes the default experience, pass `true` into the second parameter.
+
+```ts
+import { validate } from "package-json-validator";
+
+const data = {
+	name: "packageJsonValidator",
+	version: "0.1.0",
+	private: true,
+	dependencies: {
+		"date-fns": "^2.29.3",
+		install: "^0.13.0",
+		react: "^18.2.0",
+		"react-chartjs-2": "^5.0.1",
+		"react-dom": "^18.2.0",
+		"react-material-ui-carousel": "^3.4.2",
+		"react-multi-carousel": "^2.8.2",
+		"react-redux": "^8.0.5",
+		"react-router-dom": "^6.4.3",
+		"react-scripts": "5.0.1",
+		redux: "^4.2.0",
+		"styled-components": "^5.3.6",
+		"web-vitals": "^2.1.4",
+	},
+	scripts: {
+		start: "react-scripts start",
+	},
+	eslintConfig: {
+		extends: ["react-app", "react-app/jest"],
+	},
+	browserslist: {
+		production: [">0.2%", "not dead", "not op_mini all"],
+		development: [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version",
+		],
+	},
+};
+
+let result = validate(data, true);
+
+console.log(result.issues.length); // 0
+console.log(result.errorMessages.length); // 0
+console.log(result.childResults.length); // 7 (one for each top-level property)
+
+result = validate({}, true);
+
+console.log(result.issues.length); // 2
+console.log(result.childResults.length); // 0
+console.log(result.errorMessages);
+// [
+//   'Missing required property: name',
+//   'Missing required property: version',
+// ]
 ```
 
 ### validateAuthor(value)

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -48,520 +48,686 @@ const npmWarningFields = {
 };
 
 describe(validate, () => {
-	describe("Basic", () => {
-		test("Input types", () => {
-			assert.ok(validate("string").critical, "string");
-			assert.ok(validate("{").critical, "malformed object");
-			assert.ok(validate("[]").critical, "array");
-			assert.ok(validate('"malformed"').critical, "quoted string");
-			assert.ok(validate("42").critical, "number");
-			assert.ok(validate("null").critical, "null");
-			assert.ok(validate("true").critical, "true");
-			assert.ok(validate("false").critical, "false");
+	describe("Legacy return type", () => {
+		describe("Basic", () => {
+			test("Input types", () => {
+				assert.ok(validate("string").critical, "string");
+				assert.ok(validate("{").critical, "malformed object");
+				assert.ok(validate("[]").critical, "array");
+				assert.ok(validate('"malformed"').critical, "quoted string");
+				assert.ok(validate("42").critical, "number");
+				assert.ok(validate("null").critical, "null");
+				assert.ok(validate("true").critical, "true");
+				assert.ok(validate("false").critical, "false");
+			});
 		});
-	});
 
-	test("Field formats", () => {
-		assert.equal(
-			validate(JSON.stringify(getPackageJson({ bin: "./path/to/program" })))
-				.valid,
-			true,
-			"bin: can be string",
-		);
-		assert.equal(
-			validate(
-				JSON.stringify(
-					getPackageJson({ bin: { "my-project": "./path/to/program" } }),
-				),
-			).valid,
-			true,
-			"bin: can be object",
-		);
-		assert.equal(
-			validate(JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })))
-				.valid,
-			false,
-			"bin: can't be an array",
-		);
-		assert.equal(
-			validate(
-				JSON.stringify(
+		test("Field formats", () => {
+			assert.equal(
+				validate(JSON.stringify(getPackageJson({ bin: "./path/to/program" })))
+					.valid,
+				true,
+				"bin: can be string",
+			);
+			assert.equal(
+				validate(
+					JSON.stringify(
+						getPackageJson({ bin: { "my-project": "./path/to/program" } }),
+					),
+				).valid,
+				true,
+				"bin: can be object",
+			);
+			assert.equal(
+				validate(JSON.stringify(getPackageJson({ bin: ["./path/to/program"] })))
+					.valid,
+				false,
+				"bin: can't be an array",
+			);
+			assert.equal(
+				validate(
+					JSON.stringify(
+						getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
+					),
+				).valid,
+				false,
+				"version should be a string",
+			);
+			assert.equal(
+				validate(getPackageJson({ bin: "./path/to/program" })).valid,
+				true,
+				"bin: can be string | with object input",
+			);
+			assert.equal(
+				validate(getPackageJson({ bin: { "my-project": "./path/to/program" } }))
+					.valid,
+				true,
+				"bin: can be object | with object input",
+			);
+			assert.equal(
+				validate(getPackageJson({ bin: ["./path/to/program"] })).valid,
+				false,
+				"bin: can't be an array | with object input",
+			);
+			assert.equal(
+				validate(
 					getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }),
+				).valid,
+				false,
+				"version should be a string | with object input",
+			);
+		});
+
+		describe("with string input", () => {
+			describe("Dependencies Ranges", () => {
+				test("Smoke", () => {
+					const json = getPackageJson({
+						dependencies: {
+							"caret-first": "^1.0.0",
+							"caret-top": "^1",
+							"catalog-named-package": "catalog:react19",
+							"catalog-package": "catalog:",
+							empty: "",
+							star: "*",
+							"svgo-v1": "npm:svgo@1.3.2",
+							"svgo-v2": "npm:svgo@2.0.3",
+							"tilde-first": "~1.2",
+							"tilde-top": "~1",
+							url: "https://github.com/michaelfaith/package-json-validator",
+							"workspace-gt-version": "workspace:>1.2.3",
+							"workspace-package-any": "workspace:*",
+							"workspace-package-caret": "workspace:^",
+							"workspace-package-no-range": "workspace:",
+							"workspace-package-tilde-version": "workspace:~1.2.3",
+							"workspace-pre-release": "workspace:1.2.3-rc.1",
+							"x-version": "1.2.x",
+						},
+						devDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						peerDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+					});
+					const result = validate(JSON.stringify(json), {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+
+				test("Smoke (opt-out of new return type)", () => {
+					const json = getPackageJson({
+						dependencies: {
+							"caret-first": "^1.0.0",
+							"caret-top": "^1",
+							"catalog-named-package": "catalog:react19",
+							"catalog-package": "catalog:",
+							empty: "",
+							star: "*",
+							"svgo-v1": "npm:svgo@1.3.2",
+							"svgo-v2": "npm:svgo@2.0.3",
+							"tilde-first": "~1.2",
+							"tilde-top": "~1",
+							url: "https://github.com/michaelfaith/package-json-validator",
+							"workspace-gt-version": "workspace:>1.2.3",
+							"workspace-package-any": "workspace:*",
+							"workspace-package-caret": "workspace:^",
+							"workspace-package-no-range": "workspace:",
+							"workspace-package-tilde-version": "workspace:~1.2.3",
+							"workspace-pre-release": "workspace:1.2.3-rc.1",
+							"x-version": "1.2.x",
+						},
+						devDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						peerDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+					});
+					const result = validate(JSON.stringify(json), false);
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+
+				it("reports a complaint when devDependencies has an invalid range", () => {
+					const json = getPackageJson({
+						devDependencies: {
+							"bad-catalog": "catalob:",
+							"bad-npm": "npm;svgo@^1.2.3",
+							"package-name": "abc123",
+						},
+					});
+
+					const result = validate(JSON.stringify(json));
+
+					assert.deepStrictEqual(result.errors, [
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency bad-catalog: catalob:",
+						},
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+						},
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency package-name: abc123",
+						},
+					]);
+				});
+
+				it("reports a complaint when peerDependencies has an invalid range", () => {
+					const json = getPackageJson({
+						peerDependencies: {
+							"package-name": "abc123",
+						},
+					});
+
+					const result = validate(JSON.stringify(json));
+
+					assert.deepStrictEqual(result.errors, [
+						{
+							field: "peerDependencies",
+							message:
+								"invalid version range for dependency package-name: abc123",
+						},
+					]);
+				});
+
+				test("Dependencies with scope", () => {
+					// reference: https://github.com/michaelfaith/package-json-validator/issues/49
+					const json = getPackageJson({
+						dependencies: {
+							"@reactivex/rxjs": "^5.0.0-alpha.7",
+							empty: "",
+							star: "*",
+							url: "https://github.com/michaelfaith/package-json-validator",
+						},
+					});
+					const result = validate(JSON.stringify(json), {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+			});
+
+			test("Required fields", () => {
+				let json = getPackageJson();
+				let result = validate(JSON.stringify(json), {
+					recommendations: false,
+					warnings: false,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+
+				["name", "version"].forEach((field) => {
+					json = getPackageJson();
+					delete json[field];
+					result = validate(JSON.stringify(json), {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, false, JSON.stringify(result));
+					assert.equal(result.warnings, undefined, JSON.stringify(result));
+				});
+				["name", "version"].forEach((field) => {
+					json = getPackageJson();
+					json.private = true;
+					delete json[field];
+					result = validate(JSON.stringify(json), {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.warnings, undefined, JSON.stringify(result));
+				});
+			});
+
+			test("Warning fields", () => {
+				let json = getPackageJson(npmWarningFields);
+				let result = validate(JSON.stringify(json), {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+
+				for (const field in npmWarningFields) {
+					json = getPackageJson(npmWarningFields);
+					delete json[field];
+					result = validate(JSON.stringify(json), {
+						recommendations: false,
+						warnings: true,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.warnings?.length, 1, JSON.stringify(result));
+				}
+			});
+
+			test("Recommended fields", () => {
+				const recommendedFields = {
+					dependencies: { "package-json-validator": "*" },
+					engines: { node: ">=0.10.3 <0.12" },
+					homepage: "http://example.com",
+					type: "module",
+				};
+				let json = getPackageJson(recommendedFields);
+				let result = validate(JSON.stringify(json), {
+					recommendations: true,
+					warnings: false,
+				});
+				expect(result.valid).toBe(true);
+				expect(result.recommendations?.length).toBeFalsy();
+
+				for (const field in recommendedFields) {
+					json = getPackageJson(recommendedFields);
+					delete json[field];
+					result = validate(JSON.stringify(json), {
+						recommendations: true,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(
+						result.recommendations?.length,
+						1,
+						JSON.stringify(result),
+					);
+				}
+			});
+
+			test("License", () => {
+				// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
+				let json = getPackageJson(npmWarningFields);
+				let result = validate(JSON.stringify(json), {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+				assert.equal(result.warnings, undefined, JSON.stringify(result));
+
+				// without the prop
+				json = getPackageJson(npmWarningFields);
+				delete json.license;
+				result = validate(JSON.stringify(json), {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+				assert.equal(result.warnings?.length, 1, JSON.stringify(result));
+			});
+		});
+		describe("with object input", () => {
+			describe("Dependencies Ranges", () => {
+				test("Smoke", () => {
+					const json = getPackageJson({
+						bundledDependencies: ["dep1", "dep2"],
+						bundleDependencies: true,
+						dependencies: {
+							"caret-first": "^1.0.0",
+							"caret-top": "^1",
+							"catalog-named-package": "catalog:react19",
+							"catalog-package": "catalog:",
+							empty: "",
+							star: "*",
+							"svgo-v1": "npm:svgo@1.3.2",
+							"svgo-v2": "npm:svgo@2.0.3",
+							"tilde-first": "~1.2",
+							"tilde-top": "~1",
+							url: "https://github.com/michaelfaith/package-json-validator",
+							"workspace-gt-version": "workspace:>1.2.3",
+							"workspace-package-any": "workspace:*",
+							"workspace-package-caret": "workspace:^",
+							"workspace-package-no-range": "workspace:",
+							"workspace-package-tilde-version": "workspace:~1.2.3",
+							"workspace-pre-release": "workspace:1.2.3-rc.1",
+							"x-version": "1.2.x",
+						},
+						devDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						optionalDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						peerDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+					});
+					const result = validate(json, {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+
+				test("Smoke (opt-out of new return type)", () => {
+					const json = getPackageJson({
+						bundledDependencies: ["dep1", "dep2"],
+						bundleDependencies: true,
+						dependencies: {
+							"caret-first": "^1.0.0",
+							"caret-top": "^1",
+							"catalog-named-package": "catalog:react19",
+							"catalog-package": "catalog:",
+							empty: "",
+							star: "*",
+							"svgo-v1": "npm:svgo@1.3.2",
+							"svgo-v2": "npm:svgo@2.0.3",
+							"tilde-first": "~1.2",
+							"tilde-top": "~1",
+							url: "https://github.com/michaelfaith/package-json-validator",
+							"workspace-gt-version": "workspace:>1.2.3",
+							"workspace-package-any": "workspace:*",
+							"workspace-package-caret": "workspace:^",
+							"workspace-package-no-range": "workspace:",
+							"workspace-package-tilde-version": "workspace:~1.2.3",
+							"workspace-pre-release": "workspace:1.2.3-rc.1",
+							"x-version": "1.2.x",
+						},
+						devDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						optionalDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+						peerDependencies: {
+							gt: ">1.2.3",
+							gteq: ">=1.2.3",
+							lt: "<1.2.3",
+							lteq: "<=1.2.3",
+							range: "1.2.3 - 2.3.4",
+							"verion-build": "1.2.3+build2012",
+						},
+					});
+					const result = validate(json, false);
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+
+				it("reports errors when devDependencies have invalid ranges", () => {
+					const json = getPackageJson({
+						devDependencies: {
+							"bad-catalog": "catalob:",
+							"bad-npm": "npm;svgo@^1.2.3",
+							"package-name": "abc123",
+						},
+					});
+
+					const result = validate(json);
+
+					assert.deepStrictEqual(result.errors, [
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency bad-catalog: catalob:",
+						},
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
+						},
+						{
+							field: "devDependencies",
+							message:
+								"invalid version range for dependency package-name: abc123",
+						},
+					]);
+				});
+
+				it("reports a complaint when peerDependencies has an invalid range", () => {
+					const json = getPackageJson({
+						peerDependencies: {
+							"package-name": "abc123",
+						},
+					});
+
+					const result = validate(json);
+
+					assert.deepStrictEqual(result.errors, [
+						{
+							field: "peerDependencies",
+							message:
+								"invalid version range for dependency package-name: abc123",
+						},
+					]);
+				});
+
+				test("Dependencies with scope", () => {
+					// reference: https://github.com/michaelfaith/package-json-validator/issues/49
+					const json = getPackageJson({
+						dependencies: {
+							"@reactivex/rxjs": "^5.0.0-alpha.7",
+							empty: "",
+							star: "*",
+							url: "https://github.com/michaelfaith/package-json-validator",
+						},
+					});
+					const result = validate(json, {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.critical, undefined, JSON.stringify(result));
+				});
+			});
+
+			test("Required fields", () => {
+				let json = getPackageJson();
+				let result = validate(json, {
+					recommendations: false,
+					warnings: false,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+
+				["name", "version"].forEach((field) => {
+					json = getPackageJson();
+					delete json[field];
+					result = validate(json, {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, false, JSON.stringify(result));
+					assert.equal(result.warnings, undefined, JSON.stringify(result));
+				});
+				["name", "version"].forEach((field) => {
+					json = getPackageJson();
+					json.private = true;
+					delete json[field];
+					result = validate(json, {
+						recommendations: false,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.warnings, undefined, JSON.stringify(result));
+				});
+			});
+
+			test("Warning fields", () => {
+				let json = getPackageJson(npmWarningFields);
+				let result = validate(json, {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+
+				for (const field in npmWarningFields) {
+					json = getPackageJson(npmWarningFields);
+					delete json[field];
+					result = validate(json, {
+						recommendations: false,
+						warnings: true,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(result.warnings?.length, 1, JSON.stringify(result));
+				}
+			});
+
+			test("Recommended fields", () => {
+				const recommendedFields = {
+					dependencies: { "package-json-validator": "*" },
+					engines: { node: ">=0.10.3 <0.12" },
+					homepage: "http://example.com",
+					type: "module",
+				};
+				let json = getPackageJson(recommendedFields);
+				let result = validate(json, {
+					recommendations: true,
+					warnings: false,
+				});
+				expect(result.valid).toBe(true);
+				expect(result.recommendations?.length).toBeFalsy();
+
+				for (const field in recommendedFields) {
+					json = getPackageJson(recommendedFields);
+					delete json[field];
+					result = validate(json, {
+						recommendations: true,
+						warnings: false,
+					});
+					assert.equal(result.valid, true, JSON.stringify(result));
+					assert.equal(
+						result.recommendations?.length,
+						1,
+						JSON.stringify(result),
+					);
+				}
+			});
+
+			test("Licenses", () => {
+				let json = getPackageJson(npmWarningFields);
+				let result = validate(json, {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+				assert.equal(result.warnings, undefined, JSON.stringify(result));
+
+				// without the prop
+				json = getPackageJson(npmWarningFields);
+				delete json.license;
+				result = validate(json, {
+					recommendations: false,
+					warnings: true,
+				});
+				assert.equal(result.valid, true, JSON.stringify(result));
+				assert.equal(result.critical, undefined, JSON.stringify(result));
+				assert.equal(result.warnings?.length, 1, JSON.stringify(result));
+			});
+		});
+	});
+
+	describe("New return type", () => {
+		it("should return an issue for invalid JSON string input", () => {
+			const result = validate("invalid", true);
+
+			expect(result.issues).toHaveLength(1);
+			expect(result.errorMessages).toHaveLength(1);
+			expect(result.errorMessages[0]).toContain("Invalid JSON");
+		});
+
+		it("should return an issue for invalid input type", () => {
+			const result = validate(123 as unknown as string, true);
+
+			expect(result.issues).toHaveLength(1);
+			expect(result.errorMessages).toHaveLength(1);
+			expect(result.errorMessages[0]).toContain("Invalid data - Not a string");
+		});
+
+		it("should return a successful Result for valid package data", () => {
+			const result = validate(getPackageJson(), true);
+
+			expect(result.issues).toHaveLength(0);
+			expect(result.errorMessages).toEqual([]);
+			expect(result.childResults.length).toBeGreaterThan(0);
+		});
+
+		it("should report a missing required field as an issue", () => {
+			const json = getPackageJson();
+			delete json.name;
+
+			const result = validate(json, true);
+
+			expect(result.issues).toHaveLength(1);
+			expect(result.errorMessages).toEqual(["Missing required property: name"]);
+		});
+
+		it("should include nested validation issues in errorMessages", () => {
+			const json = getPackageJson({
+				devDependencies: {
+					"package-name": "abc123",
+				},
+			});
+
+			const result = validate(json, true);
+
+			expect(result.issues).toHaveLength(0);
+			expect(result.errorMessages).toContain(
+				"invalid version range for dependency package-name: abc123",
+			);
+			expect(
+				result.childResults.some((child) =>
+					child.errorMessages.includes(
+						"invalid version range for dependency package-name: abc123",
+					),
 				),
-			).valid,
-			false,
-			"version should be a string",
-		);
-		assert.equal(
-			validate(getPackageJson({ bin: "./path/to/program" })).valid,
-			true,
-			"bin: can be string | with object input",
-		);
-		assert.equal(
-			validate(getPackageJson({ bin: { "my-project": "./path/to/program" } }))
-				.valid,
-			true,
-			"bin: can be object | with object input",
-		);
-		assert.equal(
-			validate(getPackageJson({ bin: ["./path/to/program"] })).valid,
-			false,
-			"bin: can't be an array | with object input",
-		);
-		assert.equal(
-			validate(getPackageJson({ dependencies: { bad: { version: "3.3.3" } } }))
-				.valid,
-			false,
-			"version should be a string | with object input",
-		);
-	});
-
-	describe("with string input", () => {
-		describe("Dependencies Ranges", () => {
-			test("Smoke", () => {
-				const json = getPackageJson({
-					dependencies: {
-						"caret-first": "^1.0.0",
-						"caret-top": "^1",
-						"catalog-named-package": "catalog:react19",
-						"catalog-package": "catalog:",
-						empty: "",
-						star: "*",
-						"svgo-v1": "npm:svgo@1.3.2",
-						"svgo-v2": "npm:svgo@2.0.3",
-						"tilde-first": "~1.2",
-						"tilde-top": "~1",
-						url: "https://github.com/michaelfaith/package-json-validator",
-						"workspace-gt-version": "workspace:>1.2.3",
-						"workspace-package-any": "workspace:*",
-						"workspace-package-caret": "workspace:^",
-						"workspace-package-no-range": "workspace:",
-						"workspace-package-tilde-version": "workspace:~1.2.3",
-						"workspace-pre-release": "workspace:1.2.3-rc.1",
-						"x-version": "1.2.x",
-					},
-					devDependencies: {
-						gt: ">1.2.3",
-						gteq: ">=1.2.3",
-						lt: "<1.2.3",
-						lteq: "<=1.2.3",
-						range: "1.2.3 - 2.3.4",
-						"verion-build": "1.2.3+build2012",
-					},
-					peerDependencies: {
-						gt: ">1.2.3",
-						gteq: ">=1.2.3",
-						lt: "<1.2.3",
-						lteq: "<=1.2.3",
-						range: "1.2.3 - 2.3.4",
-						"verion-build": "1.2.3+build2012",
-					},
-				});
-				const result = validate(JSON.stringify(json), {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.critical, undefined, JSON.stringify(result));
-			});
-
-			it("reports a complaint when devDependencies has an invalid range", () => {
-				const json = getPackageJson({
-					devDependencies: {
-						"bad-catalog": "catalob:",
-						"bad-npm": "npm;svgo@^1.2.3",
-						"package-name": "abc123",
-					},
-				});
-
-				const result = validate(JSON.stringify(json));
-
-				assert.deepStrictEqual(result.errors, [
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency bad-catalog: catalob:",
-					},
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					},
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency package-name: abc123",
-					},
-				]);
-			});
-
-			it("reports a complaint when peerDependencies has an invalid range", () => {
-				const json = getPackageJson({
-					peerDependencies: {
-						"package-name": "abc123",
-					},
-				});
-
-				const result = validate(JSON.stringify(json));
-
-				assert.deepStrictEqual(result.errors, [
-					{
-						field: "peerDependencies",
-						message:
-							"invalid version range for dependency package-name: abc123",
-					},
-				]);
-			});
-
-			test("Dependencies with scope", () => {
-				// reference: https://github.com/michaelfaith/package-json-validator/issues/49
-				const json = getPackageJson({
-					dependencies: {
-						"@reactivex/rxjs": "^5.0.0-alpha.7",
-						empty: "",
-						star: "*",
-						url: "https://github.com/michaelfaith/package-json-validator",
-					},
-				});
-				const result = validate(JSON.stringify(json), {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.critical, undefined, JSON.stringify(result));
-			});
-		});
-
-		test("Required fields", () => {
-			let json = getPackageJson();
-			let result = validate(JSON.stringify(json), {
-				recommendations: false,
-				warnings: false,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-
-			["name", "version"].forEach((field) => {
-				json = getPackageJson();
-				delete json[field];
-				result = validate(JSON.stringify(json), {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, false, JSON.stringify(result));
-				assert.equal(result.warnings, undefined, JSON.stringify(result));
-			});
-			["name", "version"].forEach((field) => {
-				json = getPackageJson();
-				json.private = true;
-				delete json[field];
-				result = validate(JSON.stringify(json), {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.warnings, undefined, JSON.stringify(result));
-			});
-		});
-
-		test("Warning fields", () => {
-			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-
-			for (const field in npmWarningFields) {
-				json = getPackageJson(npmWarningFields);
-				delete json[field];
-				result = validate(JSON.stringify(json), {
-					recommendations: false,
-					warnings: true,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.warnings?.length, 1, JSON.stringify(result));
-			}
-		});
-
-		test("Recommended fields", () => {
-			const recommendedFields = {
-				dependencies: { "package-json-validator": "*" },
-				engines: { node: ">=0.10.3 <0.12" },
-				homepage: "http://example.com",
-				type: "module",
-			};
-			let json = getPackageJson(recommendedFields);
-			let result = validate(JSON.stringify(json), {
-				recommendations: true,
-				warnings: false,
-			});
-			expect(result.valid).toBe(true);
-			expect(result.recommendations?.length).toBeFalsy();
-
-			for (const field in recommendedFields) {
-				json = getPackageJson(recommendedFields);
-				delete json[field];
-				result = validate(JSON.stringify(json), {
-					recommendations: true,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.recommendations?.length, 1, JSON.stringify(result));
-			}
-		});
-
-		test("License", () => {
-			// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
-			let json = getPackageJson(npmWarningFields);
-			let result = validate(JSON.stringify(json), {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings, undefined, JSON.stringify(result));
-
-			// without the prop
-			json = getPackageJson(npmWarningFields);
-			delete json.license;
-			result = validate(JSON.stringify(json), {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings?.length, 1, JSON.stringify(result));
-		});
-	});
-	describe("with object input", () => {
-		describe("Dependencies Ranges", () => {
-			test("Smoke", () => {
-				const json = getPackageJson({
-					bundledDependencies: ["dep1", "dep2"],
-					bundleDependencies: true,
-					dependencies: {
-						"caret-first": "^1.0.0",
-						"caret-top": "^1",
-						"catalog-named-package": "catalog:react19",
-						"catalog-package": "catalog:",
-						empty: "",
-						star: "*",
-						"svgo-v1": "npm:svgo@1.3.2",
-						"svgo-v2": "npm:svgo@2.0.3",
-						"tilde-first": "~1.2",
-						"tilde-top": "~1",
-						url: "https://github.com/michaelfaith/package-json-validator",
-						"workspace-gt-version": "workspace:>1.2.3",
-						"workspace-package-any": "workspace:*",
-						"workspace-package-caret": "workspace:^",
-						"workspace-package-no-range": "workspace:",
-						"workspace-package-tilde-version": "workspace:~1.2.3",
-						"workspace-pre-release": "workspace:1.2.3-rc.1",
-						"x-version": "1.2.x",
-					},
-					devDependencies: {
-						gt: ">1.2.3",
-						gteq: ">=1.2.3",
-						lt: "<1.2.3",
-						lteq: "<=1.2.3",
-						range: "1.2.3 - 2.3.4",
-						"verion-build": "1.2.3+build2012",
-					},
-					optionalDependencies: {
-						gt: ">1.2.3",
-						gteq: ">=1.2.3",
-						lt: "<1.2.3",
-						lteq: "<=1.2.3",
-						range: "1.2.3 - 2.3.4",
-						"verion-build": "1.2.3+build2012",
-					},
-					peerDependencies: {
-						gt: ">1.2.3",
-						gteq: ">=1.2.3",
-						lt: "<1.2.3",
-						lteq: "<=1.2.3",
-						range: "1.2.3 - 2.3.4",
-						"verion-build": "1.2.3+build2012",
-					},
-				});
-				const result = validate(json, {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.critical, undefined, JSON.stringify(result));
-			});
-
-			it("reports errors when devDependencies have invalid ranges", () => {
-				const json = getPackageJson({
-					devDependencies: {
-						"bad-catalog": "catalob:",
-						"bad-npm": "npm;svgo@^1.2.3",
-						"package-name": "abc123",
-					},
-				});
-
-				const result = validate(json);
-
-				assert.deepStrictEqual(result.errors, [
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency bad-catalog: catalob:",
-					},
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-					},
-					{
-						field: "devDependencies",
-						message:
-							"invalid version range for dependency package-name: abc123",
-					},
-				]);
-			});
-
-			it("reports a complaint when peerDependencies has an invalid range", () => {
-				const json = getPackageJson({
-					peerDependencies: {
-						"package-name": "abc123",
-					},
-				});
-
-				const result = validate(json);
-
-				assert.deepStrictEqual(result.errors, [
-					{
-						field: "peerDependencies",
-						message:
-							"invalid version range for dependency package-name: abc123",
-					},
-				]);
-			});
-
-			test("Dependencies with scope", () => {
-				// reference: https://github.com/michaelfaith/package-json-validator/issues/49
-				const json = getPackageJson({
-					dependencies: {
-						"@reactivex/rxjs": "^5.0.0-alpha.7",
-						empty: "",
-						star: "*",
-						url: "https://github.com/michaelfaith/package-json-validator",
-					},
-				});
-				const result = validate(json, {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.critical, undefined, JSON.stringify(result));
-			});
-		});
-
-		test("Required fields", () => {
-			let json = getPackageJson();
-			let result = validate(json, {
-				recommendations: false,
-				warnings: false,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-
-			["name", "version"].forEach((field) => {
-				json = getPackageJson();
-				delete json[field];
-				result = validate(json, {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, false, JSON.stringify(result));
-				assert.equal(result.warnings, undefined, JSON.stringify(result));
-			});
-			["name", "version"].forEach((field) => {
-				json = getPackageJson();
-				json.private = true;
-				delete json[field];
-				result = validate(json, {
-					recommendations: false,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.warnings, undefined, JSON.stringify(result));
-			});
-		});
-
-		test("Warning fields", () => {
-			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-
-			for (const field in npmWarningFields) {
-				json = getPackageJson(npmWarningFields);
-				delete json[field];
-				result = validate(json, {
-					recommendations: false,
-					warnings: true,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.warnings?.length, 1, JSON.stringify(result));
-			}
-		});
-
-		test("Recommended fields", () => {
-			const recommendedFields = {
-				dependencies: { "package-json-validator": "*" },
-				engines: { node: ">=0.10.3 <0.12" },
-				homepage: "http://example.com",
-				type: "module",
-			};
-			let json = getPackageJson(recommendedFields);
-			let result = validate(json, {
-				recommendations: true,
-				warnings: false,
-			});
-			expect(result.valid).toBe(true);
-			expect(result.recommendations?.length).toBeFalsy();
-
-			for (const field in recommendedFields) {
-				json = getPackageJson(recommendedFields);
-				delete json[field];
-				result = validate(json, {
-					recommendations: true,
-					warnings: false,
-				});
-				assert.equal(result.valid, true, JSON.stringify(result));
-				assert.equal(result.recommendations?.length, 1, JSON.stringify(result));
-			}
-		});
-
-		test("Licenses", () => {
-			// https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
-			let json = getPackageJson(npmWarningFields);
-			let result = validate(json, {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings, undefined, JSON.stringify(result));
-
-			// without the prop
-			json = getPackageJson(npmWarningFields);
-			delete json.license;
-			result = validate(json, {
-				recommendations: false,
-				warnings: true,
-			});
-			assert.equal(result.valid, true, JSON.stringify(result));
-			assert.equal(result.critical, undefined, JSON.stringify(result));
-			assert.equal(result.warnings?.length, 1, JSON.stringify(result));
+			).toBe(true);
 		});
 	});
 });

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -674,20 +674,14 @@ describe(validate, () => {
 	});
 
 	describe("New return type", () => {
-		it("should return an issue for invalid JSON string input", () => {
-			const result = validate("invalid", true);
-
-			expect(result.issues).toHaveLength(1);
-			expect(result.errorMessages).toHaveLength(1);
-			expect(result.errorMessages[0]).toContain("Invalid JSON");
+		it("should throw for invalid JSON string input", () => {
+			expect(() => validate("invalid", true)).toThrow("Invalid JSON");
 		});
 
-		it("should return an issue for invalid input type", () => {
-			const result = validate(123 as unknown as string, true);
-
-			expect(result.issues).toHaveLength(1);
-			expect(result.errorMessages).toHaveLength(1);
-			expect(result.errorMessages[0]).toContain("Invalid data - Not a string");
+		it("should throw for invalid input type", () => {
+			expect(() => validate(123 as unknown as string, true)).toThrow(
+				"Invalid data - Not a string",
+			);
 		});
 
 		it("should return a successful Result for valid package data", () => {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -214,10 +214,8 @@ export function validate(
 			const parsedData = typeof data == "object" ? data : parse(data);
 
 			// If this is a string, then it's an error message resulting from parsing.
-			// So we add it as an issue and return immediately.
 			if (typeof parsedData == "string") {
-				result.addIssue(parsedData);
-				return result;
+				throw new Error(parsedData);
 			}
 
 			const map = getSpecMap(

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,6 @@
 import type { SpecMap } from "./Spec.types.ts";
 
+import { Result } from "./Result.ts";
 import {
 	validateAuthor,
 	validateBin,
@@ -153,17 +154,12 @@ const parse = (data: string) => {
 	return parsed;
 };
 
-export type ValidateFunction = (
-	data: object | string,
-	options?: ValidationOptions,
-) => ValidationOutput;
-
 export interface ValidationOptions {
 	recommendations?: boolean;
 	warnings?: boolean;
 }
 
-export interface ValidationOutput {
+interface LegacyValidationOutput {
 	critical?: Record<string, string> | string;
 	errors?: ValidationError[];
 	recommendations?: string[];
@@ -182,13 +178,87 @@ interface ValidationError {
  * @param options The options for validation, if using the deprecated spec name parameter.
  * @returns an object with the validation results.
  */
-export const validate: ValidateFunction = (
+export function validate(
 	data: object | string,
-	options: ValidationOptions = {},
-): ValidationOutput => {
+	options?: ValidationOptions,
+): LegacyValidationOutput;
+
+/**
+ * Validate a package.json object (or string) against the npm spec.
+ * @param data The package.json data to validate, either as a string or an object.
+ * @param useNewReturnType Opt-in to use the new return type (Result) instead of the legacy output.  This is a temporary option to allow users to migrate to the new return type before it becomes the default in a future major release.
+ * @returns an object with the validation results.
+ */
+export function validate(
+	data: object | string,
+	useNewReturnType: false,
+): LegacyValidationOutput;
+
+/**
+ * Validate a package.json object (or string) against the npm spec.
+ * @param data The package.json data to validate, either as a string or an object.
+ * @param useNewReturnType Opt-in to use the new return type (Result) instead of the legacy output.  This is a temporary option to allow users to migrate to the new return type before it becomes the default in a future major release.
+ * @returns an object with the validation results.
+ */
+export function validate(data: object | string, useNewReturnType: true): Result;
+export function validate(
+	data: object | string,
+	optionsOrUseNewReturnType: boolean | ValidationOptions = {},
+) {
+	// Should we use the new return type?
+	if (typeof optionsOrUseNewReturnType === "boolean") {
+		if (optionsOrUseNewReturnType) {
+			const result = new Result();
+
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+			const parsedData = typeof data == "object" ? data : parse(data);
+
+			// If this is a string, then it's an error message resulting from parsing.
+			// So we add it as an issue and return immediately.
+			if (typeof parsedData == "string") {
+				result.addIssue(parsedData);
+				return result;
+			}
+
+			const map = getSpecMap(
+				(parsedData.private as boolean | undefined) ?? false,
+			);
+
+			const keys = Object.keys(map);
+			for (let i = 0; i < keys.length; i++) {
+				const name = keys[i];
+				const property = map[name];
+
+				if (parsedData[name] === undefined) {
+					if (property.required) {
+						result.addIssue(`Missing required property: ${name}`);
+					}
+					continue;
+				}
+
+				// Each validator returns a Result object that will be a child of the main result.
+				// This allows us to maintain the full structure of the validation results,
+				// including which fields have which issues, and any nested child results for complex fields.
+				const propertyResult = property.validate(parsedData[name]);
+				result.addChildResult(i, propertyResult);
+			}
+
+			return result;
+		} else {
+			return validateLegacy(data, {});
+		}
+	} else {
+		return validateLegacy(data, optionsOrUseNewReturnType);
+	}
+}
+
+const validateLegacy = (
+	data: object | string,
+	options: ValidationOptions,
+): LegacyValidationOutput => {
 	// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 	const parsed = typeof data == "object" ? data : parse(data);
-	const out: ValidationOutput = { valid: false };
+	const out: LegacyValidationOutput = { valid: false };
 
 	if (typeof parsed == "string") {
 		out.critical = parsed;


### PR DESCRIPTION

<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #752
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates `validate` to allow for opting in to a new return type.  By passing `true` into the second parameter of `validate`, the function will return a `Result` object, instead of the legacy (less granular) return type. In the next major version, the new return type will become the default.
