### PR TITLE
ci: add workflow to trigger ci on label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,12 @@ on:
     types: [opened, reopened, synchronize]
   push:
     branches: [main]
-  workflow_dispatch: ~
+  repository_dispatch:
+    types: [run-ci] # Triggered by the Label Trigger workflow when the "ci" label is added to a pull request
+
+env:
+  # Use the dispatch payload if available, otherwise use the default SHA
+  TARGET_SHA: ${{ github.event.client_payload.sha || github.sha }}
 
 jobs:
   build:
@@ -13,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: node lib/index.mjs
@@ -21,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm dedupe --check --prefer-offline
   lint:
@@ -28,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm build
       - run: pnpm lint
@@ -36,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm lint:knip
   prettier:
@@ -43,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm format --list-different
   test:
@@ -50,6 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm run test --coverage
       - uses: codecov/codecov-action@v5
@@ -61,5 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ env.TARGET_SHA }}
       - uses: ./.github/actions/prepare
       - run: pnpm typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
-    branches:
-      - main
+    branches: [main]
+  workflow_dispatch: ~
 
 jobs:
   build:

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Trigger CI
         run: |
-          gh workflow run ci.yml \
-            --repo ${{ github.repository }} \
-            --ref ${{ github.event.pull_request.head.ref }}
-        env:
-          GH_TOKEN: ${{ steps.create_token.outputs.token }}
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.create_token.outputs.token }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://github.com{{ github.repository }}/dispatches \
+            -d '{"event_type": "run-ci", "client_payload": {"pr_number": "${{ github.event.pull_request.number }}", "sha": "${{ github.event.pull_request.head.sha }}"}}'

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Trigger CI
         run: |
           gh workflow run ci.yml \
+            --repo ${{ github.repository }} \
             --ref ${{ github.event.pull_request.head.ref }}
         env:
           GH_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -18,8 +18,11 @@ jobs:
 
       - name: Trigger CI
         run: |
-          curl -X POST \
-            -H "Authorization: Bearer ${{ steps.create_token.outputs.token }}" \
+          gh api \
+            --method POST \
             -H "Accept: application/vnd.github.v3+json" \
-            https://github.com{{ github.repository }}/dispatches \
-            -d '{"event_type": "run-ci", "client_payload": {"pr_number": "${{ github.event.pull_request.number }}", "sha": "${{ github.event.pull_request.head.sha }}"}}'
+            /repos/${{ github.repository }}/dispatches \
+            -f event_type='run-ci' \
+            -F client_payload='{"pr_number": ${{ github.event.pull_request.number }}, "sha": "${{ github.event.pull_request.head.sha }}"}'
+        env:
+          GH_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -18,6 +18,11 @@ jobs:
 
       - name: Trigger CI
         run: |
+          if [ -z "${{ steps.create_token.outputs.token }}" ]; then
+            echo "Error: Token generation failed"
+            exit 1
+          fi
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github.v3+json" \

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -23,11 +23,12 @@ jobs:
             exit 1
           fi
 
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            /repos/${{ github.repository }}/dispatches \
-            -f event_type='run-ci' \
-            -F client_payload='{"pr_number": ${{ github.event.pull_request.number }}, "sha": "${{ github.event.pull_request.head.sha }}"}'
+          echo '{
+            "event_type": "run-ci",
+            "client_payload": {
+              "pr_number": ${{ github.event.pull_request.number }},
+              "sha": "${{ github.event.pull_request.head.sha }}"
+            }
+          }' | gh api /repos/${{ github.repository }}/dispatches --input -
         env:
           GH_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/label-trigger.yml
+++ b/.github/workflows/label-trigger.yml
@@ -1,0 +1,24 @@
+name: Label Trigger
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  label-filter:
+    if: github.event.label.name == 'ci'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Token
+        id: create_token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.FAITHBOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.FAITHBOT_APP_PRIVATE_KEY }}
+
+      - name: Trigger CI
+        run: |
+          gh workflow run ci.yml \
+            --ref ${{ github.event.pull_request.head.ref }}
+        env:
+          GH_TOKEN: ${{ steps.create_token.outputs.token }}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new "Label Trigger" workflow that uses a token generated for a new App I installed to trigger the ci workflow iff the "ci" label is added to a pr.  This avoids the problem of unnecessarily running ci on PRs when other labels are applied.
