### PR TITLE
fix(validateDependencies): improve version validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
+		"npm-package-arg": "^13.0.2",
 		"semver": "^7.7.2",
 		"validate-npm-package-license": "^3.0.4",
 		"validate-npm-package-name": "^7.0.0"
@@ -71,6 +72,7 @@
 		"@eslint/js": "10.0.1",
 		"@eslint/markdown": "8.0.1",
 		"@types/node": "24.12.0",
+		"@types/npm-package-arg": "^6.1.4",
 		"@types/semver": "7.7.0",
 		"@types/validate-npm-package-license": "3.0.3",
 		"@types/validate-npm-package-name": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      npm-package-arg:
+        specifier: ^13.0.2
+        version: 13.0.2
       semver:
         specifier: ^7.7.2
         version: 7.7.4
@@ -30,6 +33,9 @@ importers:
       '@types/node':
         specifier: 24.12.0
         version: 24.12.0
+      '@types/npm-package-arg':
+        specifier: ^6.1.4
+        version: 6.1.4
       '@types/semver':
         specifier: 7.7.0
         version: 7.7.0
@@ -861,6 +867,9 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
+  '@types/npm-package-arg@6.1.4':
+    resolution: {integrity: sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==}
+
   '@types/semver@7.7.0':
     resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
@@ -1417,6 +1426,10 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   html-entities@2.6.0:
     resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
 
@@ -1614,6 +1627,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1782,6 +1799,10 @@ packages:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
 
+  npm-package-arg@13.0.2:
+    resolution: {integrity: sha512-IciCE3SY3uE84Ld8WZU23gAPPV9rIYod4F+rc+vJ7h7cwAJt9Vk6TVsK60ry7Uj3SRS3bqRRIGuTp9YVlk6WNA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   object-deep-merge@2.0.0:
     resolution: {integrity: sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==}
 
@@ -1871,6 +1892,10 @@ packages:
     resolution: {integrity: sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==}
     engines: {node: '>=14'}
     hasBin: true
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2798,6 +2823,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/npm-package-arg@6.1.4': {}
+
   '@types/semver@7.7.0': {}
 
   '@types/unist@3.0.3': {}
@@ -3411,6 +3438,10 @@ snapshots:
 
   hookable@6.1.1: {}
 
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
@@ -3585,6 +3616,8 @@ snapshots:
       wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
+
+  lru-cache@11.3.5: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3951,6 +3984,13 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
+  npm-package-arg@13.0.2:
+    dependencies:
+      hosted-git-info: 9.0.2
+      proc-log: 6.1.0
+      semver: 7.7.4
+      validate-npm-package-name: 7.0.2
+
   object-deep-merge@2.0.0: {}
 
   obug@2.1.1: {}
@@ -4074,6 +4114,8 @@ snapshots:
       sh-syntax: 0.5.8
 
   prettier@3.8.0: {}
+
+  proc-log@6.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -226,17 +226,12 @@ describe(validate, () => {
 						{
 							field: "devDependencies",
 							message:
-								"invalid version range for dependency bad-catalog: catalob:",
+								'invalid version spec for dependency `bad-catalog`: Unsupported URL Type "catalob:": catalob:',
 						},
 						{
 							field: "devDependencies",
 							message:
-								"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-						},
-						{
-							field: "devDependencies",
-							message:
-								"invalid version range for dependency package-name: abc123",
+								"invalid version spec for dependency `bad-npm`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -244,7 +239,7 @@ describe(validate, () => {
 				it("reports a complaint when peerDependencies has an invalid range", () => {
 					const json = getPackageJson({
 						peerDependencies: {
-							"package-name": "abc123",
+							"package-name": "jsr;",
 						},
 					});
 
@@ -254,7 +249,7 @@ describe(validate, () => {
 						{
 							field: "peerDependencies",
 							message:
-								"invalid version range for dependency package-name: abc123",
+								"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -513,17 +508,12 @@ describe(validate, () => {
 						{
 							field: "devDependencies",
 							message:
-								"invalid version range for dependency bad-catalog: catalob:",
+								'invalid version spec for dependency `bad-catalog`: Unsupported URL Type "catalob:": catalob:',
 						},
 						{
 							field: "devDependencies",
 							message:
-								"invalid version range for dependency bad-npm: npm;svgo@^1.2.3",
-						},
-						{
-							field: "devDependencies",
-							message:
-								"invalid version range for dependency package-name: abc123",
+								"invalid version spec for dependency `bad-npm`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -531,7 +521,7 @@ describe(validate, () => {
 				it("reports a complaint when peerDependencies has an invalid range", () => {
 					const json = getPackageJson({
 						peerDependencies: {
-							"package-name": "abc123",
+							"package-name": "jsr;",
 						},
 					});
 
@@ -541,7 +531,7 @@ describe(validate, () => {
 						{
 							field: "peerDependencies",
 							message:
-								"invalid version range for dependency package-name: abc123",
+								"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -705,7 +695,7 @@ describe(validate, () => {
 		it("should include nested validation issues in errorMessages", () => {
 			const json = getPackageJson({
 				devDependencies: {
-					"package-name": "abc123",
+					"package-name": ">-1.0.0",
 				},
 			});
 
@@ -713,12 +703,12 @@ describe(validate, () => {
 
 			expect(result.issues).toHaveLength(0);
 			expect(result.errorMessages).toContain(
-				"invalid version range for dependency package-name: abc123",
+				"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 			);
 			expect(
 				result.childResults.some((child) =>
 					child.errorMessages.includes(
-						"invalid version range for dependency package-name: abc123",
+						"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
 					),
 				),
 			).toBe(true);

--- a/src/validate.test.ts
+++ b/src/validate.test.ts
@@ -231,7 +231,7 @@ describe(validate, () => {
 						{
 							field: "devDependencies",
 							message:
-								"invalid version spec for dependency `bad-npm`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+								"invalid version spec for dependency `bad-npm`: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -249,7 +249,7 @@ describe(validate, () => {
 						{
 							field: "peerDependencies",
 							message:
-								"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+								"invalid version spec for dependency `package-name`: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -513,7 +513,7 @@ describe(validate, () => {
 						{
 							field: "devDependencies",
 							message:
-								"invalid version spec for dependency `bad-npm`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+								"invalid version spec for dependency `bad-npm`: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -531,7 +531,7 @@ describe(validate, () => {
 						{
 							field: "peerDependencies",
 							message:
-								"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+								"invalid version spec for dependency `package-name`: tags may not have any characters that encodeURIComponent encodes",
 						},
 					]);
 				});
@@ -703,12 +703,12 @@ describe(validate, () => {
 
 			expect(result.issues).toHaveLength(0);
 			expect(result.errorMessages).toContain(
-				"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+				"invalid version spec for dependency `package-name`: tags may not have any characters that encodeURIComponent encodes",
 			);
 			expect(
 				result.childResults.some((child) =>
 					child.errorMessages.includes(
-						"invalid version spec for dependency `package-name`: invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+						"invalid version spec for dependency `package-name`: tags may not have any characters that encodeURIComponent encodes",
 					),
 				),
 			).toBe(true);

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -34,6 +34,7 @@ describe(validateDependencies, () => {
 			star: "*",
 			"svgo-v1": "npm:svgo@1.3.2",
 			"svgo-v2": "npm:svgo@2.0.3",
+			tag: "beta",
 			"tilde-first": "~1.2",
 			"tilde-top": "~1",
 			url: "https://github.com/michaelfaith/package-json-validator",
@@ -81,6 +82,7 @@ describe(validateDependencies, () => {
 			_lteq: "<=1.2.3",
 			_range: "1.2.3 - 2.3.4",
 			_star: "*",
+			_tag: "beta",
 			"_tilde-first": "~1.2",
 			"_tilde-top": "~1",
 			"_verion-build": "1.2.3+build2012",
@@ -132,24 +134,45 @@ describe(validateDependencies, () => {
 		});
 	});
 
-	it("should report an issue when dependencies have an invalid range", () => {
-		const dependencies = {
-			"bad-catalog": "catalob:",
-			"bad-jsr": "jsr;@scope/package@^1.0.0",
-			"bad-npm": "npm;svgo@^1.2.3",
-			"invalid-git-protocol": "git+foo://github.com/npm/cli.git",
-			"invalid-github-reference-bad-reponame": "some/package?",
-			"invalid-github-reference-bad-username": "some--user/package",
-			"invalid-github-reference-too-many-slashes": "some/package/subpath",
-			"package-name": "abc123",
-		};
+	describe("should report an issue when dependencies have an invalid range", () => {
+		it.for([
+			[
+				"bad catalog: protocol",
+				"bad-catalog",
+				"catalob:",
+				`Unsupported URL Type "catalob:": catalob:`,
+			],
+			[
+				"bad jsr: protocol",
+				"bad-jsr",
+				"jsr;@scope\\package@^1.0.0",
+				"invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+			],
+			[
+				"bad npm: protocol",
+				"bad-npm",
+				"npm;svgo@^1.2.3",
+				"invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+			],
+			[
+				"invalid git protocol",
+				"invalid-git-protocol",
+				"git+foo://github.com/npm/cli.git",
+				'Unsupported URL Type "git+foo:": git+foo://github.com/npm/cli.git',
+			],
+		] satisfies [
+			testCaseName: string,
+			name: string,
+			spec: string,
+			errorMessage: string,
+		][])("%s", ([, name, spec, errorMessage]) => {
+			const dependencies = { [name]: spec };
 
-		const result = validateDependencies(dependencies);
+			const result = validateDependencies(dependencies);
 
-		expect(result.issues).toEqual([]);
-		Object.entries(dependencies).forEach(([key, value], i) => {
-			expect(result.childResults[i].errorMessages).toEqual([
-				`invalid version range for dependency ${key}: ${value}`,
+			expect(result.issues).toEqual([]);
+			expect(result.childResults[0].errorMessages).toStrictEqual([
+				`invalid version spec for dependency \`${name}\`: ${errorMessage}`,
 			]);
 		});
 	});

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -146,13 +146,13 @@ describe(validateDependencies, () => {
 				"bad jsr: protocol",
 				"bad-jsr",
 				"jsr;@scope\\package@^1.0.0",
-				"invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+				"tags may not have any characters that encodeURIComponent encodes",
 			],
 			[
 				"bad npm: protocol",
 				"bad-npm",
 				"npm;svgo@^1.2.3",
-				"invalid tag name: tags may not have any characters that encodeURIComponent encodes",
+				"tags may not have any characters that encodeURIComponent encodes",
 			],
 			[
 				"invalid git protocol",

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import npmPackageArg from "npm-package-arg";
+import { describe, expect, it, vi } from "vitest";
 
 import { validateDependencies } from "./validateDependencies.ts";
 
@@ -145,7 +146,7 @@ describe(validateDependencies, () => {
 			[
 				"bad jsr: protocol",
 				"bad-jsr",
-				"jsr;@scope\\package@^1.0.0",
+				"jsr;svgo@^1.0.0",
 				"tags may not have any characters that encodeURIComponent encodes",
 			],
 			[
@@ -208,5 +209,36 @@ describe(validateDependencies, () => {
 			"the value is `null`, but should be a record of dependencies",
 		]);
 		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should display raw version when error is thrown", () => {
+		const spy = vi
+			.spyOn(npmPackageArg, "resolve")
+			.mockThrow(new Error("Some error"));
+
+		const result = validateDependencies({
+			"bad-catalog": "catalob:",
+		});
+		expect(result.errorMessages).toEqual([
+			"invalid version spec for dependency `bad-catalog`: catalob:",
+		]);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults[0].errorMessages).toStrictEqual([
+			"invalid version spec for dependency `bad-catalog`: catalob:",
+		]);
+		spy.mockRestore();
+	});
+
+	it("should return an issue when the dependency version is not a string", () => {
+		const result = validateDependencies({
+			"bad-version-type": 123,
+		});
+		expect(result.errorMessages).toEqual([
+			"dependency version for `bad-version-type` should be a string: 123",
+		]);
+		expect(result.issues).toEqual([]);
+		expect(result.childResults[0].errorMessages).toStrictEqual([
+			"dependency version for `bad-version-type` should be a string: 123",
+		]);
 	});
 });

--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -120,11 +120,11 @@ describe(validateDependencies, () => {
 		});
 		expect(result.issues).toEqual([]);
 		expect(result.errorMessages).toEqual(
-			publishedKeys.map((key) => `invalid dependency package name: ${key}`),
+			publishedKeys.map((key) => `invalid dependency package name: \`${key}\``),
 		);
 		publishedKeys.forEach((key, i) => {
 			expect(result.childResults[i].errorMessages).toEqual([
-				`invalid dependency package name: ${key}`,
+				`invalid dependency package name: \`${key}\``,
 			]);
 		});
 		unpublishedKeys.forEach((_, i) => {

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -7,7 +7,7 @@ const parseSpecWithNpa = (
 	spec: string,
 ): { error: string } | { result: ReturnType<typeof npmPackageArg> } => {
 	try {
-		const result = npmPackageArg(`dummy@${spec}`);
+		const result = npmPackageArg.resolve("dummy", spec);
 		return { result };
 	} catch (error) {
 		if (

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -92,29 +92,24 @@ export const validateDependencies = (value: unknown): Result => {
 				childResult.addIssue(`invalid dependency package name: \`${pkg}\``);
 			}
 
-			if (!isSpecString || !npaResult) {
+			if (isSpecString && npaResult) {
+				if (!("result" in npaResult)) {
+					const isPackageManagerSpecificNotation =
+						PACKAGE_MANAGER_SPECIFIC_PROTOCOLS.some((protocol) =>
+							spec.startsWith(`${protocol}:`),
+						);
+
+					if (!isPackageManagerSpecificNotation) {
+						childResult.addIssue(
+							`invalid version spec for dependency \`${pkg}\`: ${npaResult.error || spec}`,
+						);
+					}
+				}
+			} else {
 				childResult.addIssue(
 					`dependency version for \`${pkg}\` should be a string: ${spec}`,
 				);
-				continue;
 			}
-
-			if ("result" in npaResult) {
-				continue;
-			}
-
-			const isPackageManagerSpecificNotation =
-				PACKAGE_MANAGER_SPECIFIC_PROTOCOLS.some((protocol) =>
-					spec.startsWith(`${protocol}:`),
-				);
-
-			if (isPackageManagerSpecificNotation) {
-				continue;
-			}
-
-			childResult.addIssue(
-				`invalid version spec for dependency \`${pkg}\`: ${npaResult.error || spec}`,
-			);
 		}
 	} else {
 		const valueType = Array.isArray(value) ? "array" : typeof value;

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -89,12 +89,12 @@ export const validateDependencies = (value: unknown): Result => {
 				!packageFormat.test(pkg) &&
 				!(isSpecString && isUnpublished(npaResult, spec))
 			) {
-				childResult.addIssue(`invalid dependency package name: ${pkg}`);
+				childResult.addIssue(`invalid dependency package name: \`${pkg}\``);
 			}
 
 			if (!isSpecString || !npaResult) {
 				childResult.addIssue(
-					`dependency version for ${pkg} should be a string: ${spec}`,
+					`dependency version for \`${pkg}\` should be a string: ${spec}`,
 				);
 				continue;
 			}

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -1,52 +1,64 @@
-import { validRange } from "semver";
+import npmPackageArg from "npm-package-arg";
 
-import { packageFormat, urlFormat } from "../formats.ts";
+import { packageFormat } from "../formats.ts";
 import { ChildResult, Result } from "../Result.ts";
 
-const isUnpublishedVersion = (version: string): boolean => {
+const parseSpecWithNpa = (
+	spec: string,
+): { error: string } | { result: ReturnType<typeof npmPackageArg> } => {
+	try {
+		const result = npmPackageArg(`dummy@${spec}`);
+		return { result };
+	} catch (error) {
+		if (
+			!(error instanceof Error) ||
+			!("code" in error && typeof error.code === "string")
+		) {
+			return { error: "" };
+		}
+
+		const { code, message: rawErrorMessage } = error;
+
+		let errorMessage = rawErrorMessage;
+		// The message contains the dummy package name, should use custom message
+		if (code === "EINVALIDTAGNAME") {
+			errorMessage =
+				"invalid tag name: tags may not have any characters that encodeURIComponent encodes";
+		}
+
+		return { error: errorMessage };
+	}
+};
+
+const isUnpublished = (
+	npaResult: ReturnType<typeof parseSpecWithNpa> | undefined,
+	spec: string,
+): boolean => {
+	if (!npaResult || "error" in npaResult) {
+		// pnpm catalogs (`catalog:`) could be published or unpublished.
+		// Ideally linting would validate the catalog itself, and then we could ignore
+		// the package names here since they'd be correctly validated there.
+		// But the catalog is elsewhere, and the better assumption is that it mostly
+		// has published packages.
+		return spec.startsWith("workspace:") || spec.startsWith("patch:");
+	}
+
+	const { type } = npaResult.result;
 	return (
-		// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#urls-as-dependencies
-		urlFormat.test(version) ||
-		// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#git-urls-as-dependencies
-		/^git(?:\+(?:ssh|http|https|file|rsync|ftp))?:/.test(version) ||
-		// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#github-urls
-		/^(?:github:)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*\/[\w.-]+(?:#|$)/.test(
-			version,
-		) ||
-		// https://pnpm.io/next/workspaces#workspace-protocol-workspace
-		version.startsWith("workspace:") ||
-		// https://yarnpkg.com/protocol/patch
-		version.startsWith("patch:") ||
-		// https://docs.npmjs.com/cli/v11/using-npm/package-spec#aliases
-		version.startsWith("npm:") ||
-		// https://docs.npmjs.com/cli/v10/configuring-npm/package-json#local-paths
-		version.startsWith("file:") ||
-		version.startsWith("../") ||
-		version.startsWith("~/") ||
-		version.startsWith("./") ||
-		version.startsWith("/") ||
-		false
+		type === "git" ||
+		type === "directory" ||
+		type === "file" ||
+		type === "remote" ||
+		type === "alias"
 	);
 };
 
-const isValidVersionRange = (version: string): boolean => {
-	// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#dependencies
-	return (
-		!!validRange(version) ||
-		version === "*" ||
-		version === "" ||
-		version === "latest" ||
-		// https://jsr.io/docs/using-packages
-		version.startsWith("jsr:") ||
-		// https://pnpm.io/next/catalogs
-		// These could be published or unpublished. Ideally linting would validate the
-		// catalog itself, and then we could ignore the package names here since they'd be
-		// correctly validated there. But the catalog is elsewhere, and the better
-		// assumption is that it mostly has published packages.
-		version.startsWith("catalog:") ||
-		isUnpublishedVersion(version)
-	);
-};
+const PACKAGE_MANAGER_SPECIFIC_PROTOCOLS = [
+	"jsr", // https://jsr.io/docs/using-packages
+	"catalog", // https://pnpm.io/next/catalogs
+	"workspace", // https://pnpm.io/next/workspaces#workspace-protocol-workspace
+	"patch", // https://yarnpkg.com/protocol/patch
+];
 
 /**
  * Validates dependencies, making sure the object is a set of key value pairs
@@ -63,29 +75,51 @@ export const validateDependencies = (value: unknown): Result => {
 	} else if (typeof value === "object" && !Array.isArray(value)) {
 		const entries = Object.entries(value);
 		for (let i = 0; i < entries.length; ++i) {
+			const entry = entries[i];
+			const pkg = entry[0];
+			const spec = entry[1] as unknown;
+
+			const isSpecString = typeof spec === "string";
+			const npaResult = isSpecString ? parseSpecWithNpa(spec) : undefined;
+
 			const childResult = new ChildResult(i);
-			const [pkg, version] = entries[i] as [string, unknown];
+			result.addChildResult(childResult);
+
 			if (
 				!packageFormat.test(pkg) &&
-				!(typeof version === "string" && isUnpublishedVersion(version))
+				!(isSpecString && isUnpublished(npaResult, spec))
 			) {
 				childResult.addIssue(`invalid dependency package name: ${pkg}`);
 			}
 
-			if (typeof version !== "string") {
+			if (!isSpecString || !npaResult) {
 				childResult.addIssue(
-					`dependency version for ${pkg} should be a string: ${version}`,
+					`dependency version for ${pkg} should be a string: ${spec}`,
 				);
-			} else if (!isValidVersionRange(version)) {
-				childResult.addIssue(
-					`invalid version range for dependency ${pkg}: ${version}`,
-				);
+				continue;
 			}
-			result.addChildResult(childResult);
+
+			if ("result" in npaResult) {
+				continue;
+			}
+
+			const isPackageManagerSpecificNotation =
+				PACKAGE_MANAGER_SPECIFIC_PROTOCOLS.some((protocol) =>
+					spec.startsWith(`${protocol}:`),
+				);
+
+			if (isPackageManagerSpecificNotation) {
+				continue;
+			}
+
+			childResult.addIssue(
+				`invalid version spec for dependency \`${pkg}\`: ${npaResult.error || spec}`,
+			);
 		}
 	} else {
 		const valueType = Array.isArray(value) ? "array" : typeof value;
 		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
 	}
+
 	return result;
 };

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -23,7 +23,7 @@ const parseSpecWithNpa = (
 		// The message contains the dummy package name, should use custom message
 		if (code === "EINVALIDTAGNAME") {
 			errorMessage =
-				"invalid tag name: tags may not have any characters that encodeURIComponent encodes";
+				"tags may not have any characters that encodeURIComponent encodes";
 		}
 
 		return { error: errorMessage };


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #690
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR substantially refactors and improves `validateDependencies` logic to reach the parity with the "official" `npm-package-arg` utility, which npm uses to parse "name + version spec" pairs passed to the `install` command.


