### PR TITLE
ci: use app-generated token for release please

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [labeled, opened, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,19 +14,25 @@ jobs:
     name: Manage Release PR
     if: github.event.repository.fork != true
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+      - name: Create Token
+        id: create_token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.FAITHBOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.FAITHBOT_APP_PRIVATE_KEY }}
+
+      - name: Release Please
         id: release
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: .github/release-please/release-please-config.${{ github.ref_name }}.json
           manifest-file: .github/release-please/release-please-manifest.json
           target-branch: ${{ github.ref_name }}
+          token: ${{ steps.create_token.outputs.token }}
 
   publish:
     name: Publish Package


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

https://github.com/michaelfaith/package-json-validator/pull/808/changes#r3144339377

I'm not positive this will work, but it's easy enough to revert if it doesn't.  If it does work, then it solves the bot-triggered release + CI problem, without needing the `labeled` trigger.  There's not really a great way to test it without spinning up a completely separate repo to test with, and with the risk being so low, I'm comfortable merging this and then reverting if needed.
