### PR TITLE
feat: add validation for `browser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,24 @@ const packageData = {
 const result = validateBin(packageData.bin);
 ```
 
+### validateBrowser(value)
+
+This function validates the value of the `browser` property of a `package.json`, checking that the value is a non-empty string.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateBrowser } from "package-json-validator";
+
+const packageData = {
+	browser: "index.umd.js",
+};
+
+const result = validateBrowser(packageData.browser);
+```
+
 ### validateBugs(value)
 
 This function validates the value of the `bugs` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { validate } from "./validate.ts";
 export {
 	validateAuthor,
 	validateBin,
+	validateBrowser,
 	validateBugs,
 	validateBundleDependencies,
 	validateConfig,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,5 +1,6 @@
 export { validateAuthor } from "./validateAuthor.ts";
 export { validateBin } from "./validateBin.ts";
+export { validateBrowser } from "./validateBrowser.ts";
 export { validateBugs } from "./validateBugs.ts";
 export { validateBundleDependencies } from "./validateBundleDependencies.ts";
 export { validateConfig } from "./validateConfig.ts";

--- a/src/validators/validateBrowser.test.ts
+++ b/src/validators/validateBrowser.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { validateBrowser } from "./validateBrowser.ts";
+
+describe(validateBrowser, () => {
+	it("should return no issues for a string", () => {
+		const result = validateBrowser("index.js");
+
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return an issue if the value is not a string (number)", () => {
+		const result = validateBrowser(123);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `number`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (object)", () => {
+		const result = validateBrowser({});
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `object`",
+		]);
+	});
+
+	it("should return an issue if the value is not a string (Array)", () => {
+		const result = validateBrowser([]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `Array`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (boolean)", () => {
+		const result = validateBrowser(true);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `boolean`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (undefined)", () => {
+		const result = validateBrowser(undefined);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be a `string`, not `undefined`",
+		]);
+	});
+
+	it("should return an issue if value is not a string (null)", () => {
+		const result = validateBrowser(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be a `string`",
+		]);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		const result = validateBrowser("");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to the module that should be used in the browser",
+		]);
+	});
+
+	it("should return an issue if the value is whitespace only", () => {
+		const result = validateBrowser("   ");
+
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the path to the module that should be used in the browser",
+		]);
+	});
+});

--- a/src/validators/validateBrowser.ts
+++ b/src/validators/validateBrowser.ts
@@ -1,0 +1,24 @@
+import { Result } from "../Result.ts";
+
+/**
+ * Validate the `browser` field in a package.json.
+ * It should be a non-empty string.
+ */
+export const validateBrowser = (value: unknown): Result => {
+	const result = new Result();
+
+	if (typeof value !== "string") {
+		if (value === null) {
+			result.addIssue("the value is `null`, but should be a `string`");
+		} else {
+			const valueType = Array.isArray(value) ? "Array" : typeof value;
+			result.addIssue(`the type should be a \`string\`, not \`${valueType}\``);
+		}
+	} else if (value.trim() === "") {
+		result.addIssue(
+			"the value is empty, but should be the path to the module that should be used in the browser",
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #830 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateBrowser` function.  It validates that the value is a non-empty string.
