### PR TITLE
feat: add validation for `libc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,25 @@ const packageData = {
 const result = validateKeywords(packageData.keywords);
 ```
 
+### validateLibc(value)
+
+This function validates the value of the `libc` property of a `package.json`.
+It takes the value, and validates that it's either a string or an Array of strings.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validateLibc } from "package-json-validator";
+
+const packageData = {
+	libc: "glibc",
+};
+
+const result = validateLibc(packageData.man);
+```
+
 ### validateLicense(value)
 
 This function validates the value of the `license` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
 	validateGypfile,
 	validateHomepage,
 	validateKeywords,
+	validateLibc,
 	validateLicense,
 	validateMain,
 	validateMan,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -17,6 +17,7 @@ export { validateFunding } from "./validateFunding.ts";
 export { validateGypfile } from "./validateGypfile.ts";
 export { validateHomepage } from "./validateHomepage.ts";
 export { validateKeywords } from "./validateKeywords.ts";
+export { validateLibc } from "./validateLibc.ts";
 export { validateLicense } from "./validateLicense.ts";
 export { validateMain } from "./validateMain.ts";
 export { validateMan } from "./validateMan.ts";

--- a/src/validators/validateLibc.test.ts
+++ b/src/validators/validateLibc.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { validateLibc } from "./validateLibc.ts";
+
+describe(validateLibc, () => {
+	it("should return no issues if the value is an empty array", () => {
+		const result = validateLibc([]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is an array with all valid strings", () => {
+		const result = validateLibc(["glibc", "musl"]);
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return no issues if the value is a valid string", () => {
+		const result = validateLibc("glibc");
+		expect(result.errorMessages).toEqual([]);
+	});
+
+	it("should return issues if the value is an array with some non-string values", () => {
+		const result = validateLibc(["glibc", null, "musl", 123]);
+		expect(result.errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+			"item at index 3 should be a string, not `number`",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"item at index 1 should be a string, not `null`",
+		]);
+		expect(result.childResults[3].errorMessages).toEqual([
+			"item at index 3 should be a string, not `number`",
+		]);
+	});
+
+	it("should return issues if the value is an array with empty strings", () => {
+		const result = validateLibc(["", "glibc", "", "musl"]);
+		expect(result.errorMessages).toEqual([
+			"item at index 0 is empty, but should be the name of a version of libc",
+			"item at index 2 is empty, but should be the name of a version of libc",
+		]);
+		expect(result.childResults).toHaveLength(4);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"item at index 0 is empty, but should be the name of a version of libc",
+		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"item at index 2 is empty, but should be the name of a version of libc",
+		]);
+	});
+
+	it("should return an issue if the value is an empty string", () => {
+		let result = validateLibc("");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the name of a version of libc",
+		]);
+		expect(result.issues).toHaveLength(1);
+
+		result = validateLibc("     ");
+		expect(result.errorMessages).toEqual([
+			"the value is empty, but should be the name of a version of libc",
+		]);
+		expect(result.issues).toHaveLength(1);
+	});
+
+	it("should return issues if the value is a number", () => {
+		const result = validateLibc(123);
+		expect(result.errorMessages).toEqual([
+			"the type should be `Array` or `string`, not `number`",
+		]);
+	});
+
+	it("should return issues if the value is an object", () => {
+		const result = validateLibc({});
+		expect(result.issues).toEqual([
+			{ message: "the type should be `Array` or `string`, not `object`" },
+		]);
+	});
+
+	it("should return issues if the value is null", () => {
+		const result = validateLibc(null);
+		expect(result.issues).toEqual([
+			{
+				message: "the value is `null`, but should be an `Array` or a `string`",
+			},
+		]);
+	});
+});

--- a/src/validators/validateLibc.ts
+++ b/src/validators/validateLibc.ts
@@ -1,0 +1,47 @@
+import { ChildResult, Result } from "../Result.ts";
+
+/**
+ * Validate the `libc` field in a package.json, which can either be
+ * a string or an Array of strings.
+ * @example ["glibc", "musl"]
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#libc
+ */
+export const validateLibc = (obj: unknown): Result => {
+	const result = new Result();
+
+	if (typeof obj === "string") {
+		if (obj.trim() === "") {
+			result.addIssue(
+				"the value is empty, but should be the name of a version of libc",
+			);
+		}
+	} else if (Array.isArray(obj)) {
+		// If it's an array, check if all items are valid strings
+		for (let i = 0; i < obj.length; i++) {
+			const childResult = new ChildResult(i);
+			const item: unknown = obj[i];
+			if (typeof item !== "string") {
+				const itemType = item === null ? "null" : typeof item;
+				childResult.addIssue(
+					`item at index ${i} should be a string, not \`${itemType}\``,
+				);
+			} else if (item.trim() === "") {
+				childResult.addIssue(
+					`item at index ${i} is empty, but should be the name of a version of libc`,
+				);
+			}
+			result.addChildResult(childResult);
+		}
+	} else if (obj == null) {
+		result.addIssue(
+			"the value is `null`, but should be an `Array` or a `string`",
+		);
+	} else {
+		const valueType = typeof obj;
+		result.addIssue(
+			`the type should be \`Array\` or \`string\`, not \`${valueType}\``,
+		);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #832
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validateLibc` function.  It validates that the value is either a string or an Array of strings.
