### PR TITLE
feat: add validation for `peerDependenciesMeta`

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,6 +889,30 @@ const packageData = {
 const result = validatePackageManager(packageData.packageManager);
 ```
 
+### validatePeerDependenciesMeta(value)
+
+This function validates the value of the `peerDependenciesMeta` property of a `package.json`.
+It takes the value, and checks that it is an object whose keys are valid package names and whose values are objects with only an `optional` property.
+The `optional` property must be a boolean.
+
+It returns a `Result` object (See [Result Types](#result-types)).
+
+#### Examples
+
+```ts
+import { validatePeerDependenciesMeta } from "package-json-validator";
+
+const packageData = {
+	peerDependenciesMeta: {
+		react: {
+			optional: true,
+		},
+	},
+};
+
+const result = validatePeerDependenciesMeta(packageData.peerDependenciesMeta);
+```
+
 ### validatePrivate(value)
 
 This function validates the value of the `private` property of a `package.json`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
 	validateOs,
 	validatePackageManager,
 	validateDependencies as validatePeerDependencies,
+	validatePeerDependenciesMeta,
 	validatePrivate,
 	validatePublishConfig,
 	validateRepository,

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -24,6 +24,7 @@ export { validateMan } from "./validateMan.ts";
 export { validateName } from "./validateName.ts";
 export { validateOs } from "./validateOs.ts";
 export { validatePackageManager } from "./validatePackageManager.ts";
+export { validatePeerDependenciesMeta } from "./validatePeerDependenciesMeta.ts";
 export { validatePrivate } from "./validatePrivate.ts";
 export { validatePublishConfig } from "./validatePublishConfig.ts";
 export { validateRepository } from "./validateRepository.ts";

--- a/src/validators/validatePeerDependenciesMeta.test.ts
+++ b/src/validators/validatePeerDependenciesMeta.test.ts
@@ -25,11 +25,19 @@ describe(validatePeerDependenciesMeta, () => {
 		]);
 	});
 
-	it("should return an issue when peerDependenciesMeta is not an object", () => {
+	it("should return an issue when peerDependenciesMeta is not an object (Array)", () => {
 		const result = validatePeerDependenciesMeta(["react"]);
 
 		expect(result.errorMessages).toEqual([
 			"the type should be `object`, not `Array`",
+		]);
+	});
+
+	it("should return an issue when peerDependenciesMeta is not an object (number)", () => {
+		const result = validatePeerDependenciesMeta(13);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `number`",
 		]);
 	});
 
@@ -52,29 +60,48 @@ describe(validatePeerDependenciesMeta, () => {
 		const result = validatePeerDependenciesMeta({
 			"@scope/package": [true],
 			react: null,
+			typescript: 123,
 		});
 
-		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults).toHaveLength(3);
 		expect(result.childResults[0].errorMessages).toEqual([
 			"the value for peer dependency metadata `@scope/package` should be an object, not `Array`",
 		]);
 		expect(result.childResults[1].errorMessages).toEqual([
 			"the value for peer dependency metadata `react` should be an object, not `null`",
 		]);
+		expect(result.childResults[2].errorMessages).toEqual([
+			"the value for peer dependency metadata `typescript` should be an object, not `number`",
+		]);
 	});
 
 	it("should return an issue when optional is not a boolean", () => {
 		const result = validatePeerDependenciesMeta({
+			"@scope/package": {
+				optional: [true],
+			},
 			react: {
 				optional: "true",
 			},
+			typescript: {
+				optional: null,
+			},
 		});
 
-		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(3);
 		expect(result.childResults[0].childResults).toHaveLength(1);
 		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
 		expect(result.childResults[0].childResults[0].errorMessages).toEqual([
+			"the `optional` property for peer dependency metadata `@scope/package` should be a boolean, not `Array`",
+		]);
+		expect(result.childResults[1].childResults).toHaveLength(1);
+		expect(result.childResults[1].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[1].childResults[0].errorMessages).toEqual([
 			"the `optional` property for peer dependency metadata `react` should be a boolean, not `string`",
+		]);
+		expect(result.childResults[2].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[2].childResults[0].errorMessages).toEqual([
+			"the `optional` property for peer dependency metadata `typescript` should be a boolean, not `null`",
 		]);
 	});
 

--- a/src/validators/validatePeerDependenciesMeta.test.ts
+++ b/src/validators/validatePeerDependenciesMeta.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePeerDependenciesMeta } from "./validatePeerDependenciesMeta.ts";
+
+describe(validatePeerDependenciesMeta, () => {
+	it("should return a Result with no issues for valid peerDependenciesMeta metadata", () => {
+		const result = validatePeerDependenciesMeta({
+			"@scope/package": { optional: false },
+			react: { optional: true },
+		});
+
+		expect(result.errorMessages).toEqual([]);
+		expect(result.issues).toHaveLength(0);
+		expect(result.childResults).toHaveLength(2);
+		result.childResults.forEach((childResult) => {
+			expect(childResult.issues).toHaveLength(0);
+		});
+	});
+
+	it("should return an issue when peerDependenciesMeta is null", () => {
+		const result = validatePeerDependenciesMeta(null);
+
+		expect(result.errorMessages).toEqual([
+			"the value is `null`, but should be an object with peer dependency metadata",
+		]);
+	});
+
+	it("should return an issue when peerDependenciesMeta is not an object", () => {
+		const result = validatePeerDependenciesMeta(["react"]);
+
+		expect(result.errorMessages).toEqual([
+			"the type should be `object`, not `Array`",
+		]);
+	});
+
+	it("should return an issue for invalid package names", () => {
+		const result = validatePeerDependenciesMeta({
+			"": { optional: true },
+			"invalid package": { optional: false },
+		});
+
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"invalid package name: ``",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"invalid package name: `invalid package`",
+		]);
+	});
+
+	it("should return issues for invalid peer dependency metadata values", () => {
+		const result = validatePeerDependenciesMeta({
+			"@scope/package": [true],
+			react: null,
+		});
+
+		expect(result.childResults).toHaveLength(2);
+		expect(result.childResults[0].errorMessages).toEqual([
+			"the value for peer dependency metadata `@scope/package` should be an object, not `Array`",
+		]);
+		expect(result.childResults[1].errorMessages).toEqual([
+			"the value for peer dependency metadata `react` should be an object, not `null`",
+		]);
+	});
+
+	it("should return an issue when optional is not a boolean", () => {
+		const result = validatePeerDependenciesMeta({
+			react: {
+				optional: "true",
+			},
+		});
+
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(1);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[0].errorMessages).toEqual([
+			"the `optional` property for peer dependency metadata `react` should be a boolean, not `string`",
+		]);
+	});
+
+	it("should return an issue for unexpected properties in metadata objects", () => {
+		const result = validatePeerDependenciesMeta({
+			react: {
+				optional: true,
+				someOtherKey: false,
+			},
+		});
+
+		expect(result.childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults).toHaveLength(2);
+		expect(result.childResults[0].childResults[0].issues).toHaveLength(0);
+		expect(result.childResults[0].childResults[1].issues).toHaveLength(1);
+		expect(result.childResults[0].childResults[1].errorMessages).toEqual([
+			"unexpected property `someOtherKey`; only `optional` is allowed in peer dependency metadata",
+		]);
+	});
+
+	it("should return an issue when optional is missing from the metadata object", () => {
+		const result = validatePeerDependenciesMeta({
+			react: {},
+		});
+
+		expect(result.childResults[0].errorMessages).toEqual([
+			"peer dependency metadata for `react` should contain the `optional` property",
+		]);
+	});
+});

--- a/src/validators/validatePeerDependenciesMeta.ts
+++ b/src/validators/validatePeerDependenciesMeta.ts
@@ -1,0 +1,89 @@
+import { packageFormat } from "../formats.ts";
+import { ChildResult, Result } from "../Result.ts";
+import { isPlainObject } from "../utils/index.ts";
+
+/**
+ * Validates the `peerDependenciesMeta` field in a package.json.
+ * The field must be an object whose keys are valid package names and whose
+ * values are objects with only an `optional` property of boolean type.
+ * @example
+ * {
+ *   "peerDependenciesMeta": {
+ *     "react": {
+ *       "optional": true
+ *     }
+ *   }
+ * }
+ * @see https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta
+ */
+export const validatePeerDependenciesMeta = (value: unknown): Result => {
+	const result = new Result();
+
+	if (value == null) {
+		result.addIssue(
+			"the value is `null`, but should be an object with peer dependency metadata",
+		);
+	} else if (typeof value === "object" && !Array.isArray(value)) {
+		const entries: [string, unknown][] = Object.entries(value);
+
+		for (let i = 0; i < entries.length; i++) {
+			const [pkg, pkgMeta] = entries[i];
+			const childResult = new ChildResult(i);
+
+			if (!packageFormat.test(pkg)) {
+				childResult.addIssue(`invalid package name: \`${pkg}\``);
+			}
+
+			if (!isPlainObject(pkgMeta)) {
+				const pkgMetaType =
+					pkgMeta === null
+						? "null"
+						: Array.isArray(pkgMeta)
+							? "Array"
+							: typeof pkgMeta;
+				childResult.addIssue(
+					`the value for peer dependency metadata \`${pkg}\` should be an object, not \`${pkgMetaType}\``,
+				);
+			} else {
+				const keys = Object.keys(pkgMeta);
+
+				for (let j = 0; j < keys.length; j++) {
+					const key = keys[j];
+					const grandChildResult = new ChildResult(j);
+					childResult.addChildResult(grandChildResult);
+
+					if (key === "optional") {
+						if (typeof pkgMeta[key] !== "boolean") {
+							const optionalType =
+								pkgMeta[key] === null
+									? "null"
+									: Array.isArray(pkgMeta[key])
+										? "Array"
+										: typeof pkgMeta[key];
+							grandChildResult.addIssue(
+								`the \`optional\` property for peer dependency metadata \`${pkg}\` should be a boolean, not \`${optionalType}\``,
+							);
+						}
+					} else {
+						grandChildResult.addIssue(
+							`unexpected property \`${key}\`; only \`optional\` is allowed in peer dependency metadata`,
+						);
+					}
+				}
+
+				if (!keys.includes("optional")) {
+					childResult.addIssue(
+						`peer dependency metadata for \`${pkg}\` should contain the \`optional\` property`,
+					);
+				}
+			}
+
+			result.addChildResult(childResult);
+		}
+	} else {
+		const valueType = Array.isArray(value) ? "Array" : typeof value;
+		result.addIssue(`the type should be \`object\`, not \`${valueType}\``);
+	}
+
+	return result;
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #835
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `validatePeerDependenciesMeta` function.  It validates that the value is an object whose keys are valid package names and whose values are objects with only an `optional` property.
The `optional` property must be a boolean.
