### PR TITLE
fix: improve error messages for `validatePeerDependenciesMeta`

### DIFF
--- a/src/validators/validatePeerDependenciesMeta.test.ts
+++ b/src/validators/validatePeerDependenciesMeta.test.ts
@@ -65,13 +65,13 @@ describe(validatePeerDependenciesMeta, () => {
 
 		expect(result.childResults).toHaveLength(3);
 		expect(result.childResults[0].errorMessages).toEqual([
-			"the value for peer dependency metadata `@scope/package` should be an object, not `Array`",
+			"the peer dependency metadata for `@scope/package` should be an object, not `Array`",
 		]);
 		expect(result.childResults[1].errorMessages).toEqual([
-			"the value for peer dependency metadata `react` should be an object, not `null`",
+			"the peer dependency metadata for `react` should be an object, not `null`",
 		]);
 		expect(result.childResults[2].errorMessages).toEqual([
-			"the value for peer dependency metadata `typescript` should be an object, not `number`",
+			"the peer dependency metadata for `typescript` should be an object, not `number`",
 		]);
 	});
 
@@ -92,16 +92,16 @@ describe(validatePeerDependenciesMeta, () => {
 		expect(result.childResults[0].childResults).toHaveLength(1);
 		expect(result.childResults[0].childResults[0].issues).toHaveLength(1);
 		expect(result.childResults[0].childResults[0].errorMessages).toEqual([
-			"the `optional` property for peer dependency metadata `@scope/package` should be a boolean, not `Array`",
+			"the value should be a boolean, not `Array`",
 		]);
 		expect(result.childResults[1].childResults).toHaveLength(1);
 		expect(result.childResults[1].childResults[0].issues).toHaveLength(1);
 		expect(result.childResults[1].childResults[0].errorMessages).toEqual([
-			"the `optional` property for peer dependency metadata `react` should be a boolean, not `string`",
+			"the value should be a boolean, not `string`",
 		]);
 		expect(result.childResults[2].childResults[0].issues).toHaveLength(1);
 		expect(result.childResults[2].childResults[0].errorMessages).toEqual([
-			"the `optional` property for peer dependency metadata `typescript` should be a boolean, not `null`",
+			"the value should be a boolean, not `null`",
 		]);
 	});
 
@@ -128,7 +128,7 @@ describe(validatePeerDependenciesMeta, () => {
 		});
 
 		expect(result.childResults[0].errorMessages).toEqual([
-			"peer dependency metadata for `react` should contain the `optional` property",
+			"the peer dependency metadata for `react` should contain the `optional` property",
 		]);
 	});
 });

--- a/src/validators/validatePeerDependenciesMeta.ts
+++ b/src/validators/validatePeerDependenciesMeta.ts
@@ -42,7 +42,7 @@ export const validatePeerDependenciesMeta = (value: unknown): Result => {
 							? "Array"
 							: typeof pkgMeta;
 				childResult.addIssue(
-					`the value for peer dependency metadata \`${pkg}\` should be an object, not \`${pkgMetaType}\``,
+					`the peer dependency metadata for \`${pkg}\` should be an object, not \`${pkgMetaType}\``,
 				);
 			} else {
 				const keys = Object.keys(pkgMeta);
@@ -61,7 +61,7 @@ export const validatePeerDependenciesMeta = (value: unknown): Result => {
 										? "Array"
 										: typeof pkgMeta[key];
 							grandChildResult.addIssue(
-								`the \`optional\` property for peer dependency metadata \`${pkg}\` should be a boolean, not \`${optionalType}\``,
+								`the value should be a boolean, not \`${optionalType}\``,
 							);
 						}
 					} else {
@@ -73,7 +73,7 @@ export const validatePeerDependenciesMeta = (value: unknown): Result => {
 
 				if (!keys.includes("optional")) {
 					childResult.addIssue(
-						`peer dependency metadata for \`${pkg}\` should contain the \`optional\` property`,
+						`the peer dependency metadata for \`${pkg}\` should contain the \`optional\` property`,
 					);
 				}
 			}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

After implementing `valid-peerDepedenciesMeta`, I want to improve the error messages a bit.