### PR TITLE
chore(deps): revert validate-npm-package-name update

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"npm-package-arg": "^13.0.2",
 		"semver": "^7.7.2",
 		"validate-npm-package-license": "^3.0.4",
-		"validate-npm-package-name": "^8.0.0"
+		"validate-npm-package-name": "^7.0.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       validate-npm-package-name:
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^7.0.0
+        version: 7.0.2
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.0
@@ -2084,10 +2084,6 @@ packages:
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
     engines: {node: ^20.17.0 || >=22.9.0}
-
-  validate-npm-package-name@8.0.0:
-    resolution: {integrity: sha512-SCv6OOV6Xj2/3cXy3dGmADluJTNcL3o7hZAglNPTe+WYuEuvxgJzxPrSDLZhF+CwyQOubqgecjMmTJGMVLWjYQ==}
-    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   vite@8.0.11:
     resolution: {integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==}
@@ -4260,8 +4256,6 @@ snapshots:
       spdx-expression-parse: 3.0.1
 
   validate-npm-package-name@7.0.2: {}
-
-  validate-npm-package-name@8.0.0: {}
 
   vite@8.0.11(@types/node@24.12.0)(jiti@2.7.0)(yaml@2.8.4):
     dependencies:


### PR DESCRIPTION
`validate-npm-package-name` updated their engines to be significantly higher than what our current level of node support is.  So, we have to revert this. #870 tracks the eventual update for our next major release.
