### PR TITLE
ci: remove node v20 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20.19.0
-          - 20
-          - 22.12.0
+          - 22.13.0
           - 22
           - 24.0.0
           - 24
@@ -79,9 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20.19.0
-          - 20
-          - 22.12.0
+          - 22.13.0
           - 22
           - 24.0.0
           - 24


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

PNPM 11 removed support for npm v20 and v22 <22.13.0, so we can no longer test those versions of node.  I think it's OK for now, but may accelerate our plans to formally remove those versions of our engines.
