### PR TITLE
fix: support `link` protocol in `validateDependencies`

### DIFF
--- a/src/validators/validateDependencies.test.ts
+++ b/src/validators/validateDependencies.test.ts
@@ -24,6 +24,7 @@ describe(validateDependencies, () => {
       'jsr-package': 'jsr:^1.0.0',
       'jsr-package-exact': 'jsr:1.0.0',
       'jsr-scoped-package': 'jsr:@valibot/valibot@^1.0.0',
+      link: 'link:../relative/path',
       lt: '<1.2.3',
       lteq: '<=1.2.3',
       patch: 'patch:some-package@^1.2.3',

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -54,10 +54,11 @@ const isUnpublished = (
 };
 
 const PACKAGE_MANAGER_SPECIFIC_PROTOCOLS = [
-  'jsr', // https://jsr.io/docs/using-packages
   'catalog', // https://pnpm.io/next/catalogs
-  'workspace', // https://pnpm.io/next/workspaces#workspace-protocol-workspace
+  'jsr', // https://jsr.io/docs/using-packages
+  'link', // https://yarnpkg.com/protocol/link
   'patch', // https://yarnpkg.com/protocol/patch
+  'workspace', // https://pnpm.io/next/workspaces#workspace-protocol-workspace
 ];
 
 /**


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #896
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds support for `link:<relativePath>` values in dependencies, which is used by both pnpm and yarn.
