### PR TITLE
chore: enable more typescript rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -111,6 +111,10 @@ export default defineConfig(
       },
     },
     rules: {
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
+
       '@typescript-eslint/no-deprecated': 'off',
       '@typescript-eslint/no-dynamic-delete': 'off',
       '@typescript-eslint/restrict-template-expressions': 'off',

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -203,7 +203,7 @@ export function validate(data: object | string, useNewReturnType: true): Result;
 export function validate(
   data: object | string,
   optionsOrUseNewReturnType: boolean | ValidationOptions = {},
-) {
+): LegacyValidationOutput | Result {
   // Should we use the new return type?
   if (typeof optionsOrUseNewReturnType === 'boolean') {
     if (optionsOrUseNewReturnType) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,
+    "isolatedModules": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "noEmit": true,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change enables `explicit-module-boundary-types`, `consistent-type-exports`, and `consistent-type-imports`, as well as `isolatedModules` in the `tsconfig.