### PR TITLE
ci: disable `pr-branch-non-default` octoguide rule

### DIFF
--- a/.github/workflows/octoguide.yml
+++ b/.github/workflows/octoguide.yml
@@ -32,13 +32,17 @@ on:
 jobs:
   octoguide:
     if: ${{ !endsWith(github.actor, '[bot]') && !contains(github.event.pull_request.labels.*.name, 'autorelease') }}
+    runs-on: ubuntu-latest
     permissions:
       discussions: write
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
     steps:
       - uses: JoshuaKGoldberg/octoguide@31040aabf74c2142cc94da2a65d97dfd90edde5c # 0.21.8
         with:
           config: strict
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          rules: |
+            {
+              "pr-branch-non-default": false
+            }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
