### PR TITLE
fix: export `ValidateDependenciesOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ const packageData = {
 const result = validateDependencies(packageData.dependencies);
 ```
 
-#### Options
+#### ValidateDependenciesOptions
 
 - `allowNamedRegistries`: Relaxes validation on dependency versions to allow for named registries, a feature [supported by pnpm](https://pnpm.io/settings#namedregistries) since 11.1.0 (Default: `false`)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,4 +39,5 @@ export {
   validateType,
   validateVersion,
   validateWorkspaces,
+  type ValidateDependenciesOptions,
 } from './validators/index.ts';

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -6,7 +6,10 @@ export { validateBundleDependencies } from './validateBundleDependencies.ts';
 export { validateConfig } from './validateConfig.ts';
 export { validateContributors } from './validateContributors.ts';
 export { validateCpu } from './validateCpu.ts';
-export { validateDependencies } from './validateDependencies.ts';
+export {
+  validateDependencies,
+  type ValidateDependenciesOptions,
+} from './validateDependencies.ts';
 export { validateDescription } from './validateDescription.ts';
 export { validateDevEngines } from './validateDevEngines.ts';
 export { validateDirectories } from './validateDirectories.ts';

--- a/src/validators/validateDependencies.ts
+++ b/src/validators/validateDependencies.ts
@@ -87,7 +87,7 @@ const PACKAGE_MANAGER_SPECIFIC_PROTOCOLS = [
 
 const parseProtocol = /^.+?:(\S+)/;
 
-interface Options {
+export interface ValidateDependenciesOptions {
   allowNamedRegistries?: boolean;
 }
 
@@ -98,7 +98,7 @@ interface Options {
  */
 export const validateDependencies = (
   value: unknown,
-  { allowNamedRegistries }: Options = {},
+  { allowNamedRegistries }: ValidateDependenciesOptions = {},
 ): Result => {
   const result = new Result();
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to package-json-validator! 💖
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1020
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/package-json-validator/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/package-json-validator/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
This change exports the options type used for `validateDependencies` second options params, for cases where downstream consumers need to export inferred types based on the function.

